### PR TITLE
Fix stu-home.desktop permissions

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -28,6 +28,7 @@
   copy:
     src: stu-home.desktop
     dest: '{{ item.homedir }}/Desktop'
+    mode: 0755
     owner: '{{ item.uid }}'
     group: '{{ item.gid }}'
   with_items: "{{ real_users }}"


### PR DESCRIPTION
The copy module in Ansible does not preserve permissions by default, so
when this file ends up on the user's desktop, the first time they
attempt to execute the file, they get a message telling them that the
file is not executable (trusted). Adjust the permissions on the file to
0755 in order to prevent that message.