### PR TITLE
Fix .desktop file validation

### DIFF
--- a/roles/aptana/templates/aptana.desktop.j2
+++ b/roles/aptana/templates/aptana.desktop.j2
@@ -1,9 +1,8 @@
 [Desktop Entry]
-Encoding=UTF-8
 Version=1.0
 Name=Aptana
 Comment=Aptana web development studio
-Categories=Application;Development;
+Categories=Development;
 Exec={{ aptana.install_path }}/AptanaStudio3
 Icon={{ aptana.install_path }}/icon.xpm
 Terminal=false

--- a/roles/drjava/templates/drjava.desktop.j2
+++ b/roles/drjava/templates/drjava.desktop.j2
@@ -1,9 +1,8 @@
 [Desktop Entry]
-Encoding=UTF-8
 Version=1.0
 Name=DrJava
 Comment=DrJava IDE for Java
-Categories=Application;Development;
+Categories=Development;
 Exec=/opt/drjava/drjava.sh
 Icon=/opt/drjava/drjava.ico
 Terminal=false

--- a/roles/eclipse/templates/eclipse.desktop.j2
+++ b/roles/eclipse/templates/eclipse.desktop.j2
@@ -1,9 +1,8 @@
 [Desktop Entry]
-Encoding=UTF-8
 Version=1.0
 Name=Eclipse
 Comment=Eclipse IDE for Java
-Categories=Application;Development;
+Categories=Development;
 Exec=/opt/eclipse/eclipse
 Icon=/opt/eclipse/icon.xpm
 Terminal=false

--- a/roles/jgrasp/templates/jgrasp.desktop.j2
+++ b/roles/jgrasp/templates/jgrasp.desktop.j2
@@ -1,9 +1,8 @@
 [Desktop Entry]
-Encoding=UTF-8
 Version=1.0
 Name=JGrasp
 Comment=JGrasp IDE for Java
-Categories=Application;Development;
+Categories=Development;
 Exec=/opt/jgrasp/bin/jgrasp
 Icon=/opt/jgrasp/data/gric48.png
 Terminal=false


### PR DESCRIPTION
Remove the deprecated Encoding key as well as the deprecated Application
category from all .desktop files.

Resolves #26 