### PR TITLE
Make the csvmprofile task idempotent

### DIFF
--- a/roles/common/files/csvmprofile
+++ b/roles/common/files/csvmprofile
@@ -1,0 +1,3 @@
+# Profile containing settings for the UUG VM
+# This file should be sourced in your .bashrc
+

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -39,7 +39,7 @@
     - openjdk-8-jdk
     - openjdk-8-source
 - name: Touch VM profile
-  file:
+  copy:
     src: csvmprofile
     dest: '{{ global_profile_path }}'
     mode: 0644

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -40,11 +40,13 @@
     - openjdk-8-source
 - name: Touch VM profile
   file:
-    path: '{{ global_profile_path }}'
+    src: csvmprofile
+    dest: '{{ global_profile_path }}'
     mode: 0644
     owner: root
     group: root
-    state: touch
+    # prevent overwriting
+    force: no
 # dest becomes path in Ansible 2.3+
 - name: Add profile to user bashrc
   lineinfile:


### PR DESCRIPTION
By using the copy module and override `force` to `no`,  `/opt/csvmprofile` does not get `touch`ed on every run of the playbook, removing a reported change. This also creates csvmprofile in the `common/files` directory to copy. Initially, the file just contains a comment describing the purpose of the file.

We may want to consider rename the task from "Touch VM profile" since nothing is actually being touched, but I haven't really thought of anything better.

This successfully copied the file to `/opt/csvmprofile` and added the block for the Finches when I ran it with the cs101 tag; I have not tested with the cs354 tag yet since I'm concerned about space requirements; however, I imagine if the block for cs101 gets added the one for cs354 will too. 