### PR TITLE
Fix wireless printing when cups isn't running

### DIFF
--- a/roles/wireless-printing/tasks/main.yml
+++ b/roles/wireless-printing/tasks/main.yml
@@ -4,6 +4,14 @@
   apt: name={{ item }} state=present
   with_items:
     - cups-client
+    - cups
+# The service must be running for lpadmin commands to work
+# and the server must be working to print
+- name: Ensure CUPS is started
+  service:
+      name: cups
+      enabled: yes
+      state: started
 # Do not indent continuation lines of a multi-line block,
 # they become newlines when parsed
 - name: Add printers


### PR DESCRIPTION
If the `cups-daemon` package is not installed then `lpadmin` cannot add printers. More confusingly, if `cups.service` is not running, we get an error when adding printers; however, subsequent runs of the playbook will succeed. The `cups` package pulls in some other useful printing utilities as well as the needed `cups-daemon`. After we have the packages installed, we can start the service.