### PR TITLE
Change install Java to install all dependencies

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -32,12 +32,13 @@
     group: '{{ item.gid }}'
     mode: 0750
   with_items: "{{ real_users }}"
-- name: Install Java runtime
+- name: Install required dependencies
   apt: name={{ item }} state=present
   with_items:
     - default-jdk
     - openjdk-8-jdk
     - openjdk-8-source
+    - libnotify-bin
 - name: Touch VM profile
   copy:
     src: csvmprofile


### PR DESCRIPTION
This ensures that libnotify-bin is installed for the handler.

Resolves #35