### PR TITLE
Fix desktop background after OEM run

### DIFF
--- a/roles/oem/tasks/main.yml
+++ b/roles/oem/tasks/main.yml
@@ -10,6 +10,10 @@
       # It was chosen arbitrarily just to allow this playbook to run
       name: curl
       autoremove: yes
+- name: Install default desktop background package
+    apt:
+        name: mint-artwork-gnome
+        state: latest
 - name: Clean the apt database
   command: apt-get clean
   # This will always report as changed otherwise


### PR DESCRIPTION
Re-install the mint-artwork-gnome package that gets removed during the
purge phase.

Resolves #38