### PR TITLE
Purge checkout, clean up formatting

### DIFF
--- a/roles/oem/files/uug-ansible-wrapper
+++ b/roles/oem/files/uug-ansible-wrapper
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 # bash is used because read -p and echo -e are undefined in POSIX sh
 
+REPO_URL="https://github.com/jmunixusers/cs-vm-build"
+
 if [ -z "$1" ]; then
     read -p "Re-run this as root. Press ENTER to exit" junk
     exit 1;
 fi
 
-if ansible-pull -U https://github.com/jmunixusers/cs-vm-build -i hosts -t "$1"; then
+if ansible-pull --url "$REPO_URL" --purge -i hosts -t "$1"; then
     exit_status=0
 else
     echo ""


### PR DESCRIPTION
Purge checkout after running to avoid problems with stale data. Also, move URL out of line to clean up formatting.