### PR TITLE
Fix libreoffice uninstall

### DIFF
--- a/roles/oem/vars/main.yml
+++ b/roles/oem/vars/main.yml
@@ -14,7 +14,7 @@ supported_courses:
 
 # https://github.com/jmunixusers/cs-vm-build/issues/11#issuecomment-347015788 
 packages_to_remove:
-    - libreoffice-*
+    - libreoffice-common
     - thunderbird*
     - hexchat*
     - pidgin*


### PR DESCRIPTION
Removing libreoffice-* catches libreoffice-style-mint, which cascades to mint-artwork-gnome and mint-themes. These three are reinstalled two tasks later, causing a ping-pong on every playbook run. libreoffice-common cascades up to all the components we care about.