### PR TITLE
Install all Java IDEs for CS149 and CS159

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,9 @@ apt will require more extensive modifications.
 * Aptana
 * Finch robot
 
-### CS149
+### CS149 & CS159
 * JGrasp
 * DrJava
-
-### CS159
 * Eclipse
 
 ### CS261

--- a/README.md
+++ b/README.md
@@ -45,9 +45,12 @@ apt will require more extensive modifications.
 * Aptana
 * Finch robot
 
-### CS149 & CS159
+### CS149
 * JGrasp
 * DrJava
+* Eclipse
+
+## CS159
 * Eclipse
 
 ### CS261

--- a/local.yml
+++ b/local.yml
@@ -9,9 +9,9 @@
     - { role: basic-prog-pkgs, tags: ["cs101"] }
     - { role: adv-prog-pkgs, tags: ["cs261"] }
     - { role: robot-pkgs, tags: ["cs354"] }
-    - { role: eclipse, tags: ["cs159"] }
-    - { role: jgrasp, tags: ["cs149"] }
-    - { role: drjava, tags: ["cs149"] }
+    - { role: eclipse, tags: ["cs149", "cs159"] }
+    - { role: jgrasp, tags: ["cs149", "cs159"] }
+    - { role: drjava, tags: ["cs149", "cs159"] }
     - { role: aptana, tags: ["cs101"] }
     - { role: finch, tags: ["cs101"] }
     - { role: task-shortcuts, tags: always, icon_mode: user }

--- a/local.yml
+++ b/local.yml
@@ -10,8 +10,8 @@
     - { role: adv-prog-pkgs, tags: ["cs261"] }
     - { role: robot-pkgs, tags: ["cs354"] }
     - { role: eclipse, tags: ["cs149", "cs159"] }
-    - { role: jgrasp, tags: ["cs149", "cs159"] }
-    - { role: drjava, tags: ["cs149", "cs159"] }
+    - { role: jgrasp, tags: ["cs149"] }
+    - { role: drjava, tags: ["cs149"] }
     - { role: aptana, tags: ["cs101"] }
     - { role: finch, tags: ["cs101"] }
     - { role: task-shortcuts, tags: always, icon_mode: user }


### PR DESCRIPTION
All three IDEs get utilized at some point in CS149 and there tends to
not be an IDE specified for CS159 (unless it is Eclipse). Install all
the IDEs for both classes, which at the moment are the only things
assigned to either tag; however, both tags are still distinct so that
additional software could be added to either course

Resolves #68