### PR TITLE
Add USB device check

### DIFF
--- a/roles/oem/tasks/main.yml
+++ b/roles/oem/tasks/main.yml
@@ -33,3 +33,8 @@
       src: welcome-to-vm.desktop
       dest: /etc/skel/Desktop/welcome-to-vm.desktop
       mode: 0644
+- name: Validate missing USB 2/3 controllers
+  shell: lspci | grep -i -e EHCI -e xHCI
+  register: lspci_output
+  failed_when: lspci_output.rc == 0
+  changed_when: False


### PR DESCRIPTION
Add check for the presence of USB 2 (EHCI) and USB 3 (xHCI) controllers
so that we don't accidentally introduce a dependency on the Extension Pack.

Relates to #65