### PR TITLE
OEM: Create /usr/local/share/applications

### DIFF
--- a/roles/oem/tasks/main.yml
+++ b/roles/oem/tasks/main.yml
@@ -33,6 +33,13 @@
       src: welcome-to-vm.desktop
       dest: /etc/skel/Desktop/welcome-to-vm.desktop
       mode: 0644
+- name: Create the /usr/local/share/applications folder
+  file:
+      path: /usr/local/share/applications
+      state: directory
+      mode: 0755
+      owner: root
+      group: staff
 - name: Validate missing USB 2/3 controllers
   shell: lspci | grep -i -e EHCI -e xHCI
   register: lspci_output


### PR DESCRIPTION
Create this directory when running the OEM steps in the hope that when
the user runs roles for courses later and the .desktop files get
installed that Cinnamon will detect them automatically (without a
reboot).

Closes #70