### PR TITLE
Filezilla: Make sure we clarify the server is stu

### DIFF
--- a/roles/filezilla/templates/fzdefaults.xml.j2
+++ b/roles/filezilla/templates/fzdefaults.xml.j2
@@ -15,7 +15,7 @@
             <MaximumMultipleConnections>0</MaximumMultipleConnections>
             <EncodingType>Auto</EncodingType>
             <BypassProxy>0</BypassProxy>
-            JMU CS Student server
+            JMU CS Student server (stu)
         </Server>
     </Servers>
 </FileZilla3>


### PR DESCRIPTION
It may not be clear to some people who only hear the server referred to
as "stu" that the server we have preconfigured is the server that they
want. Specify the name in parenthesis so that it's clear. Having just
"stu" feels like it also might be ambigious to some students who want
extra confirmation they're connecting to the right thing. Both together
seems like a decent medium.