### PR TITLE
 Fix existing documentation URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # JMU UUG virtual machine build script
 This is an attempt to use Ansible to build the computer science student
 virtual machine. Extended end user documentation using these tasks and the VM
-is available [separately](https://jmunixusers.github.io/presentations/welcome-to-vm.html).
+is available [separately](https://jmunixusers.github.io/presentations/vm/).
 
 ```
 apt-get install ansible git

--- a/roles/oem/files/welcome-to-vm.desktop
+++ b/roles/oem/files/welcome-to-vm.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=VM README
 Type=Link
-URL=https://jmunixusers.github.io/presentations/welcome-to-vm.html
+URL=https://jmunixusers.github.io/presentations/vm/welcome-to-vm.html
 Icon=text-html
 


### PR DESCRIPTION
The presentations repository is being reorganized. Adjust all existing
links to any documentation to ensure that no links 404.

Resolves #98 

See: jmunixusers/presentations#19