### PR TITLE
Update JGrasp URL (#113)

### DIFF
--- a/roles/jgrasp/vars/main.yml
+++ b/roles/jgrasp/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 # vars file for jgrasp
 jgrasp:
-  url: 'http://www.jgrasp.org/dl4g/jgrasp/jgrasp204_03.zip'
-  hash: '1aafdc19ef8ed8e4e15cbdcdabe383fc18428d63'
+  url: 'http://www.jgrasp.org/dl4g/jgrasp/jgrasp204_04.zip'
+  hash: 'aedf88b1bbe4c532c18f274ddd85546a97c0004d'
   zip: '{{ global_base_path }}/jgrasp.zip'
   install_path: '{{ global_base_path }}/jgrasp'


### PR DESCRIPTION
Download the latest version of JGrasp. The 2.04_03 is no longer
available and breaks the playbook