### PR TITLE
Document Eclipse URL

### DIFF
--- a/roles/eclipse/vars/main.yml
+++ b/roles/eclipse/vars/main.yml
@@ -1,6 +1,8 @@
 ---
 # vars file for eclipse
 eclipse:
+  # Ensure the URL does not specify a mirror and that &r=1 is at the end, which
+  # directly links to the file and not the web page with a download button
   url: 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/oxygen/3/eclipse-java-oxygen-3-linux-gtk-x86_64.tar.gz&r=1'
   hash: '2b7605ab5806dfe2738ec978f39c1a1d0c7be547'
   zip: '{{ global_base_path }}/eclipse.tar.gz'


### PR DESCRIPTION
The comment adds information about the Eclipse download URL format to hopefully guard against links that contain a specific mirror or that don't directly link to the file.

Since this may change the future, I understand if this is not a desirable addition.