### PR TITLE
Fix warning of syntax deprecation

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -42,7 +42,7 @@
       'uid': item.value.1, 'gid': item.value.2 } ] }}
   with_dict: "{{ getent_passwd }}"
   when:
-    - item.value.4 | match ("^/home/")
+    - item.value.4 is match ("^/home/")
     - item.value.5 != "/bin/false"
 - name: Upgrade installed software
   apt:


### PR DESCRIPTION
Changes the syntax when finding real users to match the warning given in Ansible 2.5. This needs to be verified to ensure that the syntax works on Ansible 2.3.

Fixes #124 