### PR TITLE
Hide mintwelcome window by default

### DIFF
--- a/roles/oem/tasks/main.yml
+++ b/roles/oem/tasks/main.yml
@@ -42,6 +42,16 @@
       src: welcome-to-vm.desktop
       dest: /etc/skel/Desktop/welcome-to-vm.desktop
       mode: 0644
+- name: Hide the mintwelcome window
+  file:
+      path: /etc/skel/.linuxmint/mintwelcome
+      mode: 0755
+      state: directory
+- name: Hide the mintwelcome window
+  file:
+      path: /etc/skel/.linuxmint/mintwelcome/norun.flag
+      mode: 0664
+      state: touch
 - name: Create the /usr/local/share/applications folder
   file:
       path: /usr/local/share/applications


### PR DESCRIPTION
This will hide the mintwelcome window when users sign in. They can, of course, still open it from the menu and change the setting themselves at a later time.

This only gets added to the OEM role to ensure we never override a user's previously-chosen settings. 