### PR TITLE
Don't run oem script on not Mint

### DIFF
--- a/roles/oem/tasks/main.yml
+++ b/roles/oem/tasks/main.yml
@@ -1,5 +1,9 @@
 ---
 # tasks file for oem
+- name: Ensure this in Linux Mint
+  assert:
+      that:
+        - "ansible_distribution == 'Linuxmint'"
 - name: Update apt cache
   apt:
       update_cache: yes

--- a/scripts/oem-build
+++ b/scripts/oem-build
@@ -28,9 +28,23 @@ error () {
 }
 
 #---
+# Exits the script if the current distro is not Linux Mint.
+#---
+assert_mint() {
+    source /etc/os-release
+    local mint_name="Linux Mint"
+    if [ "$NAME" != "$mint_name" ]; then
+        error "The OEM role is only compatible with ${mint_name}. Not $NAME"
+    fi
+}
+
+#---
 # Performs the actual preparation of the machine
 #---
 main () {
+
+    assert_mint
+
     user "Updating apt package cache"
     sudo apt-get update
 


### PR DESCRIPTION
The OEM role doesn't work if you're not running on Mint. There are a lot of assumptions about packages and other things in there. The script should assert that it's being run on Mint and the OEM role should as well.