### PR TITLE
Fix OEM role detecting Mint in Mint 19

### DIFF
--- a/roles/oem/tasks/main.yml
+++ b/roles/oem/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: Ensure this in Linux Mint
   assert:
       that:
-        - "ansible_distribution == 'Linuxmint'"
+        - "ansible_distribution == 'Linuxmint' or ansible_distribution == 'Linux Mint'"
 - name: Update apt cache
   apt:
       update_cache: yes


### PR DESCRIPTION
In Mint 19, ansible_distribution is "Linux Mint" rather than "Linuxmint"
as it was in previous versions of Mint. I have not checked whether this
is a change in Ansible or Mint; however, it is a second value that we
need to support.