### PR TITLE
Fix Mint 19 dependencies

### DIFF
--- a/roles/oem/vars/main.yml
+++ b/roles/oem/vars/main.yml
@@ -4,7 +4,6 @@ oem_base_path: /opt
 
 packages_to_install:
     - zenity
-    - mint-artwork-gnome
 
 # https://github.com/jmunixusers/cs-vm-build/issues/11#issuecomment-347015788 
 packages_to_remove:


### PR DESCRIPTION
mint-artwork-gnome is no longer necessary and actually no longer exists
in the tara repos. The issues we saw previously where windows and
dialogs were missing some of their decorations no longer seems to occur.