### PR TITLE
Avoid needing a password for back-to-back runs

### DIFF
--- a/roles/task-shortcuts/files/edu.jmu.uug.ansiblewrapper.policy
+++ b/roles/task-shortcuts/files/edu.jmu.uug.ansiblewrapper.policy
@@ -15,7 +15,7 @@
                  active session (TTY or X11). -->
             <allow_any>no</allow_any>
             <allow_inactive>no</allow_inactive>
-            <allow_active>auth_admin</allow_active>
+            <allow_active>auth_admin_keep</allow_active>
         </defaults>
         <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/ansible-pull</annotate>
     </action>


### PR DESCRIPTION
This will allow users to only need to type their password probably once
every few runs. This essentially works like `sudo` where rather than
being prompted, the user can continue to execute it for a brief period
of time.