### PR TITLE
Fix real user detection

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -39,15 +39,15 @@
     real_users: >-
       {{ real_users|default([]) +
       [ {'user': item.key, 'homedir': item.value.4,
-      'uid': item.value.1, 'gid': item.value.2 } ] }}
+      'uid': item.value.1 | int, 'gid': item.value.2 } ] }}
   with_dict: "{{ getent_passwd }}"
   when:
     # Ideally, this would pull from useradd.conf to get the lower bound for
     # regular user UIDs; however, 1000 is relatively universal
-    - item.value.1 >= 1000
+    - item.value.1 | int >= 1000
     - item.value.4 is match ("^/home/")
     - item.value.5 != "/bin/false"
-    - item.value.5 != "/sbin/nologin"
+    - item.value.5 != "/usr/sbin/nologin"
 - name: Upgrade installed software
   apt:
       upgrade: safe


### PR DESCRIPTION
This ensures the the UID is always treated as an int so that it can be
compared. Additionally, we now check that the shell is not
/usr/sbin/nologin since the path seems to have changed in Mint 19.

Resolves #143 