### PR TITLE
Fix detection of Linux Mint

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -26,7 +26,7 @@
     owner: root
     group: root
     mode: 0644
-  when: ansible_distribution == "Linuxmint"
+  when: ansible_distribution == "Linuxmint" or ansible_distribution == "Linux Mint"
 - name: Refresh apt cache
   apt:
     update_cache: yes


### PR DESCRIPTION
Ensure that whenever we check for Mint we allow both "Linuxmint" and
"Linux Mint".

Resolves #146 