### PR TITLE
Don't allow direct interaction with the terminal

### DIFF
--- a/roles/task-shortcuts/files/uug_ansible_wrapper.py
+++ b/roles/task-shortcuts/files/uug_ansible_wrapper.py
@@ -143,6 +143,7 @@ class AnsibleWrapperWindow(Gtk.Window):
 
         # Add the terminal to the window
         self.terminal = Vte.Terminal()
+        self.terminal.set_sensitive(False)
         self.terminal.connect("child-exited", self.sub_command_exited)
         contents.pack_end(self.terminal, True, True, 0)
         self.vbox.pack_end(contents, True, True, 0)


### PR DESCRIPTION
Curently the terminal will accept keyboard input. This means that the
user can press Ctrl-C and stop Ansible from running. This isn't a huge
deal, but since users will never need to interact with Ansible, we may
as well disable the ability to interact with it.

Resolves #151