### PR TITLE
Fix compilation of Java files in jGRASP

### DIFF
--- a/roles/jgrasp/tasks/main.yml
+++ b/roles/jgrasp/tasks/main.yml
@@ -1,5 +1,9 @@
 ---
 # tasks file for jgrasp
+- name: Install jGRASP dependencies
+  apt:
+    name: lsb-core
+    state: latest
 - name: Check JGrasp
   stat:
     path: '{{ jgrasp.zip }}'


### PR DESCRIPTION
lsb-core is required for the jGRASP "wedge"

Fixes #155 