### PR TITLE
Fix jGRASP name capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ apt will require more extensive modifications.
 ### CS149
 * DrJava
 * Eclipse
-* JGrasp
+* jGRASP
 
 ### CS159
 * Eclipse

--- a/roles/jgrasp/meta/main.yml
+++ b/roles/jgrasp/meta/main.yml
@@ -1,6 +1,6 @@
 galaxy_info:
   author: Unix Users Group
-  description: Installs the JGrasp IDE
+  description: Installs the jGRASP IDE
   company: James Madison University
   license: MIT
   min_ansible_version: 2.1

--- a/roles/jgrasp/tasks/main.yml
+++ b/roles/jgrasp/tasks/main.yml
@@ -4,26 +4,26 @@
   apt:
     name: lsb-core
     state: latest
-- name: Check JGrasp
+- name: Check jGRASP
   stat:
     path: '{{ jgrasp.zip }}'
   register: st
 - block:
-    - name: Fetch JGrasp zip
+    - name: Fetch jGRASP zip
       get_url:
         url: '{{ jgrasp.url }}'
         dest: '{{ jgrasp.zip }}'
         force: yes
-    - name: Remove old JGrasp directory
+    - name: Remove old jGRASP directory
       file:
         path: '{{ jgrasp.install_path }}'
         state: absent
-    - name: Unpack JGrasp zip
+    - name: Unpack jGRASP zip
       unarchive:
         dest: '{{ global_base_path }}'
         src: '{{ jgrasp.zip }}'
   when: st.stat.checksum|default("") != jgrasp.hash
-- name: Install JGrasp desktop icon
+- name: Install jGRASP desktop icon
   template:
     src: jgrasp.desktop.j2
     dest: /usr/local/share/applications/jgrasp.desktop

--- a/roles/jgrasp/templates/jgrasp.desktop.j2
+++ b/roles/jgrasp/templates/jgrasp.desktop.j2
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
-Name=JGrasp
-Comment=JGrasp IDE for Java
+Name=jGRASP
+Comment=jGRASP IDE for Java
 Categories=Development;
 Exec={{ jgrasp.install_path }}/bin/jgrasp
 Icon={{ jgrasp.install_path }}/data/gric48.png


### PR DESCRIPTION
In the past we've used JGrasp, but it seems like the correct styling is
jGRASP, so we should fix that in places where the name is displayed;
however, variables will remain all lowercase "jgrasp".