### PR TITLE
Force menu cache update

### DIFF
--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -1,5 +1,8 @@
 ---
 # handlers file for common
+- name: Update desktop menu
+  command:
+    /usr/bin/update-desktop-database
 - name: Suggest restart
   command: >-
     notify-send -u critical "JMU Software Change" 

--- a/roles/drjava/tasks/main.yml
+++ b/roles/drjava/tasks/main.yml
@@ -20,6 +20,8 @@
     src: drjava.desktop.j2
     dest: /usr/local/share/applications/drjava.desktop
     mode: 0644
+  notify:
+    - Update desktop menu
 - name: Install DrJava start script
   template:
     src: drjava.sh.j2

--- a/roles/eclipse/tasks/main.yml
+++ b/roles/eclipse/tasks/main.yml
@@ -31,3 +31,5 @@
     src: eclipse.desktop.j2
     dest: /usr/local/share/applications/eclipse.desktop
     mode: 0644
+  notify:
+    - Update desktop menu

--- a/roles/jgrasp/tasks/main.yml
+++ b/roles/jgrasp/tasks/main.yml
@@ -28,3 +28,5 @@
     src: jgrasp.desktop.j2
     dest: /usr/local/share/applications/jgrasp.desktop
     mode: 0644
+  notify:
+    - Update desktop menu


### PR DESCRIPTION
Add handler to call update-desktop-database and notify to all
known users of desktop menu files (JGrasp, DrJava, and Eclipse).

Closes #153 