### PR TITLE
Fix suggest restart handler

### DIFF
--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -9,6 +9,8 @@
     "Changes have been made to your machine that 
     will only take effect when log out or when 
     you reboot. Please do this immediately."
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ item.uid }}"
   become: yes
   become_user: "{{ item.user }}"
   with_items: "{{ real_users }}"

--- a/roles/robot-pkgs/handlers/main.yml
+++ b/roles/robot-pkgs/handlers/main.yml
@@ -4,6 +4,8 @@
 - name: USB controllers warning
   command: >-
     zenity --warning --text {{ usb_warning_msg }}
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ item.uid }}"
   become: yes
   become_user: "{{ item.user }}"
   with_items: "{{ real_users }}"

--- a/roles/task-shortcuts/files/edu.jmu.uug.ansiblewrapper.policy
+++ b/roles/task-shortcuts/files/edu.jmu.uug.ansiblewrapper.policy
@@ -18,6 +18,9 @@
             <allow_active>auth_admin_keep</allow_active>
         </defaults>
         <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/ansible-pull</annotate>
+        <!-- Allows pkexec to copy $DISPLAY and $XAUTHORITY, needed for
+             GUI-related things such as notify-send -->
+        <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
     </action>
 
 </policyconfig>


### PR DESCRIPTION
The handler currently seems to be broken because of a lack of access to
$DISPLAY, $XAUTHORITY, and $XDG_RUNTIME_DIR. This should resolve that by
allowing pkexec to copy the first two and we manually set the last
option.

This should also fix any potential issues with the robot-pkgs role.

Resolves #164 