### PR TITLE
Add Ubuntu partner repo

### DIFF
--- a/roles/common/templates/mint.j2
+++ b/roles/common/templates/mint.j2
@@ -15,3 +15,6 @@ deb {{ mirror }} {{ ubuntu_release }}-security main restricted universe multiver
 deb {{ mirror }} {{ ansible_distribution_release }} main upstream import backport
 
 {% endfor %}
+
+# Parter repository (necessary for optional media codecs)
+deb http://archive.canonical.com/ubuntu bionic partner

--- a/roles/common/templates/ubuntu.j2
+++ b/roles/common/templates/ubuntu.j2
@@ -8,3 +8,6 @@ deb {{ mirror }} {{ ubuntu_release }}-backports main restricted universe multive
 deb {{ mirror }} {{ ubuntu_release }}-security main restricted universe multiverse
 
 {% endfor %}
+
+# Parter repository (necessary for optional media codecs)
+deb http://archive.canonical.com/ubuntu bionic partner


### PR DESCRIPTION
This is included by default in Mint; I am unsure why we weren't
including it previously. This will be required to install the media
codecs.

Resolves #175 