### PR TITLE
Fix timeshift

### DIFF
--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -14,3 +14,9 @@
   become: yes
   become_user: "{{ item.user }}"
   with_items: "{{ real_users }}"
+- name: Restart update manager
+  shell:
+    nohup mintupdate-launcher
+  become: yes
+  become_user: "{{ item.user }}"
+  loop: "{{ real_users }}"

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -58,6 +58,7 @@
     - libnotify-bin
     - openjdk-8-jdk
     - openjdk-8-source
+    - python-psutil
     - unzip    
     - vim
     - vim-gnome    
@@ -92,3 +93,11 @@
     create: no
   ignore_errors: yes
   with_items: "{{ real_users }}"
+- name: Remove Timeshift warning
+  dconf:
+      key: "/com/linuxmint/updates/warn-about-timeshift"
+      value: "false"
+      state: present
+  become: yes
+  become_user: "{{ item.user }}"
+  loop: "{{ real_users }}"

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -101,3 +101,4 @@
   become: yes
   become_user: "{{ item.user }}"
   loop: "{{ real_users }}"
+  notify: Restart update manager

--- a/roles/oem/vars/main.yml
+++ b/roles/oem/vars/main.yml
@@ -80,6 +80,7 @@ packages_to_remove:
     - pix*
     - rhythmbox*
     - simple-scan
+    - timeshift
     - thunderbird*
     - tomboy
     - transmission*


### PR DESCRIPTION
This removes the Timeshift package on oem runs and removes the warning in the Mint update manager.

Closes #200 