### PR TITLE
Fix terminal scrolling in wrapper

### DIFF
--- a/roles/task-shortcuts/files/uug_ansible_wrapper.py
+++ b/roles/task-shortcuts/files/uug_ansible_wrapper.py
@@ -152,7 +152,12 @@ class AnsibleWrapperWindow(Gtk.Window):
 
         # Add the terminal to the window
         self.terminal = Vte.Terminal()
-        self.terminal.set_sensitive(False)
+        # Prevent the user from entering text or ^C
+        self.terminal.set_input_enabled(False)
+        # Ensure that if text is written, the user sees it
+        self.terminal.set_scroll_on_output(True)
+        # Ensure that all lines can be seen (default is only 512)
+        self.terminal.set_scrollback_lines(-1)
         self.terminal.connect("child-exited", self.sub_command_exited)
         contents.pack_end(self.terminal, True, True, 0)
         self.vbox.pack_end(contents, True, True, 0)


### PR DESCRIPTION
Currently the terminal prevents users from inputting things (such as ^C)
by using the set_sensitive(False) function call. Unfortunately, this
also disables scrolling. The set_input_enabled(False) call may make
this better. This also adds a call to set_scroll_on_output to ensure
that any text written to the terminal is seen to avoid situations where
a user scrolls and then doesn't see any output so it looks like Playbook
is stuck.

Closes #190 