### PR TITLE
Specify warning window dimensions

### DIFF
--- a/roles/robot-pkgs/handlers/main.yml
+++ b/roles/robot-pkgs/handlers/main.yml
@@ -3,7 +3,7 @@
 
 - name: USB controllers warning
   command: >-
-    zenity --warning --text {{ usb_warning_msg }}
+    zenity --warning --text {{ usb_warning_msg }} --width=300 --height=200
   environment:
     XDG_RUNTIME_DIR: "/run/user/{{ item.uid }}"
   become: yes


### PR DESCRIPTION
This fixes the odd default dimensions for the USB warning.

I'm certainly open to suggestions for different window dimensions.

![new-dimensions](https://user-images.githubusercontent.com/7274568/47540817-d84d9780-d8a4-11e8-917c-fb52e724b3bb.png)

Resolves #212 