### PR TITLE
Fix branch handling for upgrades

### DIFF
--- a/roles/common/files/uug_ansible_wrapper.py
+++ b/roles/common/files/uug_ansible_wrapper.py
@@ -666,7 +666,7 @@ def valdiate_config_settings(self):
             self, Gtk.MessageType.WARNING, Gtk.ButtonsType.OK, header, warning_prompt
         )
             
-    return warning_bool
+    return warning_prompt is None
 
 
 def validate_branch():

--- a/roles/common/files/uug_ansible_wrapper.py
+++ b/roles/common/files/uug_ansible_wrapper.py
@@ -23,6 +23,8 @@ from gi.repository import Gtk, Vte
 from gi.repository import GLib
 from gi.repository import GdkPixbuf
 
+DEFAULT_GIT_REMOTE = "https://github.com/jmunixusers/cs-vm-build"
+
 # If no tags are passed to ansible-pull, all of them will be run and I am
 # uncertain of the outcome of passing -t with no tags. To avoid this, always
 # ensure that common is run by adding it to this list and disabling the
@@ -47,7 +49,6 @@ USER_CONFIG = {
 }
 NAME = "JMU CS VM Configuration"
 VERSION = "Spring 2019"
-DEFAULT_GIT_REMOTE = "https://github.com/jmunixusers/cs-vm-build"
 
 def main():
     """
@@ -599,62 +600,76 @@ def validate_branch_settings(self):
     system_exists = system_version in ls_remote
     chosen_exists = chosen_branch in ls_remote
         
-    if chosen_remote == DEFAULT_GIT_REMOTE:
-        if (chosen_branch == "master"):
-            warning_prompt = (
-                "You are currently on an unstable development branch (master) of the configuration tool. "
-                "You should consider switching to the release branch for your Linux Mint version. "
-                "The recommended configuration settings for your release version of Linux Mint are:" 
-                "\nRelease: %(0)s and URL: %(1)s" % {
-                    '0': get_distro_release_name(),
-                    '1': DEFAULT_GIT_REMOTE
-                }
-            )
-            header = "Using testing branch master"
-        elif branch_mismatch and looks_minty and system_exists and chosen_exists:
-            warning_prompt = (
-                "You are using a version of the configuration tool meant for a different release of Linux Mint. " 
-                "You should consider upgrading branches. "
-                "The recommended configuration settings for your release version of Linux Mint are:"
-                "\nRelease: %(0)s and URL: %(1)s" % {
-                    '0': system_version,
-                    '1': DEFAULT_GIT_REMOTE
-                }
-            )
-            header = "Current branch is outdated"
-        elif branch_mismatch and looks_minty and system_exists and (not chosen_exists):
-            warning_prompt = (
-                "Your current Linux Mint version does not exist as a branch on the specified remote url. "
-                "You should consider switching to the master branch. "
-                "The recommended configuration settings for your release version of Linux Mint are:" 
-                "\nRelease: %(0)s and URL: %(1)s" % {
-                    '0': system_version,
-                    '1': DEFAULT_GIT_REMOTE
-                }
-            )
-            header = "Linux Mint version not found on URL"
-        elif system_exists and (not chosen_exists):
-            warning_prompt = (
-                "Your currently chosen branch does not exist on the chosen url. "
-                "You should fix your remote url or switch to a branch that exist on that url. "
-                "The recommended configuration settings for your release version of Linux Mint are:" 
-                "\nRelease: %(0)s and URL: %(1)s" % {
-                    '0': system_version,
-                    '1': DEFAULT_GIT_REMOTE
-                }
-            )
-            header = "Branch does not exist on specified remote URL"
-        elif (not system_exists) and (not chosen_exists):
-            warning_prompt = (
-                "We do not support your current OS and the branch chosen does not exist on the chosen remote URL. "
-                "You should consider switching to the master branch. "
-                "The recommended configuration settings for your release version of Linux Mint are:" 
-                "\nRelease: %(0)s and URL: %(1)s" % {
-                    '0': "master",
-                    '1': DEFAULT_GIT_REMOTE
-                }
-            )
-            header = "OS not supported and branch not found"
+    if chosen_remote != DEFAULT_GIT_REMOTE:
+        return True
+    
+    if (chosen_branch == "master"):
+        warning_prompt = (
+            "You are currently on an unstable development branch (master) of the configuration tool. "
+            "You should consider switching to the release branch for your Linux Mint version. "
+            "The recommended configuration settings for your release version of Linux Mint are:" 
+            "\nRelease: %(0)s and URL: %(1)s" % {
+                '0': get_distro_release_name(),
+                '1': DEFAULT_GIT_REMOTE
+            }
+        )
+        header = "Using testing branch master"
+    elif branch_mismatch and looks_minty and system_exists and chosen_exists:
+        warning_prompt = (
+            "You are using a version of the configuration tool meant for a different release of Linux Mint. " 
+            "You should consider upgrading branches. "
+            "The recommended configuration settings for your release version of Linux Mint are:"
+            "\nRelease: %(0)s and URL: %(1)s" % {
+                '0': system_version,
+                '1': DEFAULT_GIT_REMOTE
+            }
+        )
+        header = "Current branch is outdated"
+    elif branch_mismatch and looks_minty and (not system_exists) and chosen_exists:
+        warning_prompt = (
+            "You are using a version of the configuration tool meant for a different release of Linux Mint. " 
+            "However, your current Linux Mint version does not exist as a branch on the specified remote url. "
+            "You should consider switching to the master branch. "
+            "The recommended configuration settings for your release version of Linux Mint are:"
+            "\nRelease: %(0)s and URL: %(1)s" % {
+                '0': "master",
+                '1': DEFAULT_GIT_REMOTE
+            }
+        )
+        header = "Current branch is outdated"
+    elif branch_mismatch and looks_minty and system_exists and (not chosen_exists):
+        warning_prompt = (
+            "Your current Linux Mint version does not exist as a branch on the specified remote url. "
+            "You should consider switching to the master branch. "
+            "The recommended configuration settings for your release version of Linux Mint are:" 
+            "\nRelease: %(0)s and URL: %(1)s" % {
+                '0': "master",
+                '1': DEFAULT_GIT_REMOTE
+            }
+        )
+        header = "Linux Mint version not found on URL"
+    elif system_exists and (not chosen_exists):
+        warning_prompt = (
+            "Your currently chosen branch does not exist on the chosen url. "
+            "You should fix your remote url or switch to a branch that exist on that url. "
+            "The recommended configuration settings for your release version of Linux Mint are:" 
+            "\nRelease: %(0)s and URL: %(1)s" % {
+                '0': system_version,
+                '1': DEFAULT_GIT_REMOTE
+            }
+        )
+        header = "Branch does not exist on specified remote URL"
+    elif (not system_exists) and (not chosen_exists):
+        warning_prompt = (
+            "We do not support your current OS and the branch chosen does not exist on the chosen remote URL. "
+            "You should consider switching to the master branch. "
+            "The recommended configuration settings for your release version of Linux Mint are:" 
+            "\nRelease: %(0)s and URL: %(1)s" % {
+                '0': "master",
+                '1': DEFAULT_GIT_REMOTE
+            }
+        )
+        header = "OS not supported and branch not found"
         
     if header and warning_prompt:
         show_dialog(

--- a/roles/common/files/uug_ansible_wrapper.py
+++ b/roles/common/files/uug_ansible_wrapper.py
@@ -677,7 +677,7 @@ def warn_using_master_branch(parent):
 
     logging.info("The chosen branch is the development branch master. Warning user about switching branches")
     warning_prompt = (
-        "You are currently an unstable development branch (master) of the configuration tool. "
+        "You are currently on an unstable development branch (master) of the configuration tool. "
         "You should consider switching to the release branch for your Linux Mint version. "
         "The correct configuration settings for your release version of Linux Mint is:" 
         "\nRelease: %(0)s and URL: %(1)s" % {

--- a/roles/common/files/uug_ansible_wrapper.py
+++ b/roles/common/files/uug_ansible_wrapper.py
@@ -39,7 +39,7 @@ COURSES = {
 USER_CONFIG_PATH = os.path.join(os.environ['HOME'], ".config", "vm_config")
 USER_CONFIG = {
     'git_branch': None,
-    'git_url': "https://github.com/jmunixusers/cs-vm-build",
+    'git_url': DEFAULT_GIT_REMOTE,
     # All roles the user has ever chosen
     'roles_all_time': ["common"],
     # Roles to be used for this particular run

--- a/roles/common/files/uug_ansible_wrapper.py
+++ b/roles/common/files/uug_ansible_wrapper.py
@@ -661,7 +661,7 @@ def warn_wrong_release_branch(parent):
     logging.info("The chosen branch is < OS releae. Warning user about switching branches")
     warning_prompt = (
         "You are using a version of the configuration tool meant for a different release of Linux Mint. " 
-        "You should consider upgrading braches. The correct configuration settings for your release version of Linux Mint is:"
+        "You should consider upgrading branches. The recommended configuration settings for your release version of Linux Mint are:"
         "\nRelease: %(0)s and URL: %(1)s" % {
             '0': get_distro_release_name(),
             '1': USER_CONFIG['git_url']

--- a/roles/common/files/uug_ansible_wrapper.py
+++ b/roles/common/files/uug_ansible_wrapper.py
@@ -435,7 +435,7 @@ class AnsibleWrapperWindow(Gtk.Window):
                     "Current branch is outdated", warning_prompt
                 )
                 return
-            elif branch_mismatch and looks_minty and (system_exists) and (not chosen_exists):
+            elif branch_mismatch and looks_minty and system_exists and (not chosen_exists):
                 no_version_msg = (
                     "Your current Linux Mint version does not exist as a branch on the specified remote url. "
                     "You should consider switching to the master branch. "

--- a/roles/common/files/uug_ansible_wrapper.py
+++ b/roles/common/files/uug_ansible_wrapper.py
@@ -389,7 +389,7 @@ class AnsibleWrapperWindow(Gtk.Window):
             invalid_branch(self)
             return
         
-        if not validate_config_settings(self):
+        if not validate_branch_settings(self):
             logging.warn("Non-optimal user branch settings.")
         
         for checkbox in self.checkboxes:

--- a/roles/common/files/uug_ansible_wrapper.py
+++ b/roles/common/files/uug_ansible_wrapper.py
@@ -388,6 +388,14 @@ class AnsibleWrapperWindow(Gtk.Window):
         if not validate_branch():
             invalid_branch(self)
             return
+        
+        if (get_distro_release_name() > USER_CONFIG['git_branch']) and (USER_CONFIG['git_url'] == "https://github.com/jmunixusers/cs-vm-build") and (USER_CONFIG['git_branch'] != "master"):
+            warn_wrong_release_branch(self)
+        elif (get_distro_release_name() < USER_CONFIG['git_branch']) and (USER_CONFIG['git_url'] == "https://github.com/jmunixusers/cs-vm-build") and (USER_CONFIG['git_branch'] != "master"):
+            warn_wrong_release_branch(self)
+
+        if (USER_CONFIG['git_branch'] == "master") and (USER_CONFIG['git_url'] == "https://github.com/jmunixusers/cs-vm-build"):
+            warn_using_master_branch(self)
 
         for checkbox in self.checkboxes:
             checkbox.set_sensitive(False)
@@ -596,7 +604,6 @@ def validate_branch():
 
     return USER_CONFIG['git_branch'] in ls_remote_output
 
-
 def invalid_branch(parent):
     """
     Displays a dialog if the branch choses does not exist on the remote
@@ -621,7 +628,6 @@ def invalid_branch(parent):
     )
     return
 
-
 def unable_to_detect_branch():
     """
     Displays a dialog to ask the user if they would like to use the master
@@ -645,6 +651,42 @@ def unable_to_detect_branch():
     else:
         USER_CONFIG['git_branch'] = "master"
         logging.info("Release set to master")
+
+def warn_wrong_release_branch(parent):
+    """
+    Displays a dialog to warn the user that their current branch in the configuration tool does not
+    match their os rlease version.
+    """
+
+    logging.info("The chosen branch is < OS releae. Warning user about switching branches")
+    warning_prompt = (
+        "You are using a version of the configuration tool meant for a different release of Linux Mint. " 
+        "You should consider upgrading braches. The correct configuration settings for your release version of Linux Mint is:"
+        "\nRelease: %(0)s and URL: %(1)s" % {
+            '0': get_distro_release_name(),
+            '1': USER_CONFIG['git_url']
+        }
+    )
+    show_dialog(parent, Gtk.MessageType.WARNING, Gtk.ButtonsType.OK,
+                           "Current branch is outdated", warning_prompt)
+
+def warn_using_master_branch(parent):
+    """
+    Displays a dialog to warn the user that their current branch in the configuration tool is the development branch master.
+    """
+
+    logging.info("The chosen branch is the development bracnch master. Warning user about switching branches")
+    warning_prompt = (
+        "You are currently an unstable development branch (master) of the configuration tool. "
+        "You should consider switching to the release branch for your Linux Mint version. "
+        "The correct configuration settings for your release version of Linux Mint is:" 
+        "\nRelease: %(0)s and URL: %(1)s" % {
+            '0': get_distro_release_name(),
+            '1': USER_CONFIG['git_url']
+        }
+    )
+    show_dialog(parent, Gtk.MessageType.WARNING, Gtk.ButtonsType.OK,
+                           "Current branch is development branch master", warning_prompt)
 
 
 def is_online(hostname="packages.linuxmint.com"):

--- a/roles/common/files/uug_ansible_wrapper.py
+++ b/roles/common/files/uug_ansible_wrapper.py
@@ -390,7 +390,7 @@ class AnsibleWrapperWindow(Gtk.Window):
             return
         
         if not validate_config_settings(self):
-            continue
+            logging.warn("Non-optimal user branch settings.")
         
         for checkbox in self.checkboxes:
             checkbox.set_sensitive(False)

--- a/roles/common/files/uug_ansible_wrapper.py
+++ b/roles/common/files/uug_ansible_wrapper.py
@@ -574,7 +574,7 @@ def get_distro_release_name():
     return release
 
 
-def valdiate_config_settings(self):
+def validate_branch_settings(self):
     """
     Warns the user of an error in the settings of the VM configuration. 
     :returns: a boolean indicating if the system should return or continue

--- a/roles/common/files/uug_ansible_wrapper.py
+++ b/roles/common/files/uug_ansible_wrapper.py
@@ -390,7 +390,7 @@ class AnsibleWrapperWindow(Gtk.Window):
             return
         
         if not validate_config_settings(self):
-            return
+            continue
         
         for checkbox in self.checkboxes:
             checkbox.set_sensitive(False)
@@ -595,7 +595,6 @@ def valdiate_config_settings(self):
     
     header = None
     warning_prompt = None
-    warning_bool = None
     
     system_exists = system_version in ls_remote
     chosen_exists = chosen_branch in ls_remote
@@ -623,7 +622,6 @@ def valdiate_config_settings(self):
                 }
             )
             header = "Current branch is outdated"
-            warning_bool = False
         elif branch_mismatch and looks_minty and system_exists and (not chosen_exists):
             warning_prompt = (
                 "Your current Linux Mint version does not exist as a branch on the specified remote url. "
@@ -635,7 +633,6 @@ def valdiate_config_settings(self):
                 }
             )
             header = "Linux Mint version not found on URL"
-            warning_bool = False
         elif system_exists and (not chosen_exists):
             warning_prompt = (
                 "Your currently chosen branch does not exist on the chosen url. "
@@ -647,7 +644,6 @@ def valdiate_config_settings(self):
                 }
             )
             header = "Branch does not exist on specified remote URL"
-            warning_bool = False
         elif (not system_exists) and (not chosen_exists):
             warning_prompt = (
                 "We do not support your current OS and the branch chosen does not exist on the chosen remote URL. "
@@ -659,7 +655,6 @@ def valdiate_config_settings(self):
                 }
             )
             header = "OS not supported and branch not found"
-            warning_bool = False
         
     if header and warning_prompt:
         show_dialog(

--- a/roles/common/files/uug_ansible_wrapper.py
+++ b/roles/common/files/uug_ansible_wrapper.py
@@ -675,7 +675,7 @@ def warn_using_master_branch(parent):
     Displays a dialog to warn the user that their current branch in the configuration tool is the development branch master.
     """
 
-    logging.info("The chosen branch is the development bracnch master. Warning user about switching branches")
+    logging.info("The chosen branch is the development branch master. Warning user about switching branches")
     warning_prompt = (
         "You are currently an unstable development branch (master) of the configuration tool. "
         "You should consider switching to the release branch for your Linux Mint version. "

--- a/roles/common/files/uug_ansible_wrapper.py
+++ b/roles/common/files/uug_ansible_wrapper.py
@@ -611,7 +611,7 @@ def valdiate_config_settings(self):
                     '1': DEFAULT_GIT_REMOTE
                 }
             )
-            header = "using testing branch master"
+            header = "Using testing branch master"
         elif branch_mismatch and looks_minty and system_exists and chosen_exists:
             warning_prompt = (
                 "You are using a version of the configuration tool meant for a different release of Linux Mint. " 


### PR DESCRIPTION
This code warns the user about using an outdated branch or about using master, and suggests the correct branch to use based on their current Mint release version. It does not hinder the code from running, only warns the user before running the code. 

Fixes parts of #211