### PR TITLE
Add VM checks in OEM role

### DIFF
--- a/oem.yml
+++ b/oem.yml
@@ -3,5 +3,5 @@
   hosts: all
   become: true
   roles:
-    - { role: oem, tags: ["oem"] }
     - { role: common, tags: ["oem"], icon_mode: oem }
+    - { role: oem, tags: ["oem"] }

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -18,6 +18,11 @@
   file:
       path: "{{ bin_path }}"
       state: directory
+- name: Ensure desktop icon directory exists
+  file:
+      path: "{{ icon_path }}"
+      state: directory
+      mode: 0755
 # The policy file must go in /usr/share/polkit-1. It is the only location that
 # policykit checks
 - name: Install policykit policy for Ansible wrapper

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,6 +1,9 @@
 ---
 # tasks file for common
 
+# All tasks in this file should be able to be run as part of the OEM or common
+# role without error as common is used in both of those.
+
 - set_fact:
     base_path: "{{ oem_base_path }}"
     icon_path: "/etc/skel/Desktop"

--- a/roles/oem/tasks/main.yml
+++ b/roles/oem/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 # tasks file for oem
+
 - name: Ensure this in Linux Mint
   assert:
       that:
@@ -23,13 +24,6 @@
   apt:
       name: "{{ packages_to_install }}"
       state: latest
-- name: Clean the apt database
-  command: apt-get clean
-  # This will always report as changed otherwise
-  changed_when: False
-  args:
-    warn: no
-  when: "ansible_virtualization_role == 'guest'"
 - name: Ensure skeleton Desktop directory exists
   file:
       path: /etc/skel/Desktop
@@ -62,13 +56,6 @@
       mode: 0755
       owner: root
       group: staff
-- name: Validate missing USB 2/3 controllers
-  shell: lspci | grep -i -e EHCI -e xHCI
-  register: lspci_output
-  failed_when: lspci_output.rc == 0
-  changed_when: False
-  when: "ansible_virtualization_role == 'guest'"
-- name: Fill disk with zeros to assist with compression
-  shell: dd if=/dev/zero of=/bigfile bs=1M; sync; rm /bigfile
-  changed_when: False
+# Some tasks should only be run when running as a guest OS.
+- include_tasks: vm_only.yml
   when: "ansible_virtualization_role == 'guest'"

--- a/roles/oem/tasks/main.yml
+++ b/roles/oem/tasks/main.yml
@@ -24,11 +24,6 @@
   apt:
       name: "{{ packages_to_install }}"
       state: latest
-- name: Ensure skeleton Desktop directory exists
-  file:
-      path: /etc/skel/Desktop
-      state: directory
-      mode: 0750
 - name: Ensure log directory exists
   file:
       path: /opt/vmtools/logs

--- a/roles/oem/tasks/main.yml
+++ b/roles/oem/tasks/main.yml
@@ -68,3 +68,7 @@
   failed_when: lspci_output.rc == 0
   changed_when: False
   when: "ansible_virtualization_role == 'guest'"
+- name: Fill disk with zeros to assist with compression
+  shell: dd if=/dev/zero of=/bigfile bs=1M; sync; rm /bigfile
+  changed_when: False
+  when: "ansible_virtualization_role == 'guest'"

--- a/roles/oem/tasks/main.yml
+++ b/roles/oem/tasks/main.yml
@@ -29,6 +29,7 @@
   changed_when: False
   args:
     warn: no
+  when: "ansible_virtualization_role == 'guest'"
 - name: Ensure skeleton Desktop directory exists
   file:
       path: /etc/skel/Desktop
@@ -66,3 +67,4 @@
   register: lspci_output
   failed_when: lspci_output.rc == 0
   changed_when: False
+  when: "ansible_virtualization_role == 'guest'"

--- a/roles/oem/tasks/vm_only.yml
+++ b/roles/oem/tasks/vm_only.yml
@@ -1,0 +1,25 @@
+---
+
+# Tasks to only be run on virtualized guest OSes.
+
+# The apt database can be fairly large and make the image unnecessarily large
+# so removing it before shipping allows us to ship a smaller image.
+- name: Clean the apt database
+  command: apt-get clean
+  # This will always report as changed otherwise
+  changed_when: False
+  args:
+    warn: no
+
+# The USB 2/3 controllers are only available with the Virtualbox
+# Extensions which are non-free software and available only under the Oracle
+# PUEL. We should ensure we have not accidentally included them.
+- name: Validate missing USB 2/3 controllers
+  shell: lspci | grep -i -e EHCI -e xHCI
+  register: lspci_output
+  failed_when: lspci_output.rc == 0
+  changed_when: False
+
+- name: Fill disk with zeros to assist with compression
+  shell: dd if=/dev/zero of=/bigfile bs=1M; sync; rm /bigfile
+  changed_when: False

--- a/scripts/oem-build
+++ b/scripts/oem-build
@@ -57,11 +57,6 @@ main () {
         || error "Unable to cd to $(dirname "$0")/.."
     ansible-playbook -i hosts -c local -K -t oem oem.yml \
         || error "Playbook failed to complete successfully"
-
-    user "Preparing to fill disk with zeros to assist with compression"
-    read -n1 -r -p "Press any key to continue or ^C to exit" junk
-    user "Filling disk with zeros to assist with compression"
-    sudo dd if=/dev/zero of=/bigfile bs=1M; sudo sync; sudo rm /bigfile
 }
 
 # Actually run the main function


### PR DESCRIPTION
As discussed in #189, there are some things that should not be done in
when the `oem` role is run on a physical machine. This adds a check for
being a virtualization guest for certain tasks.