### PR TITLE
Clean up unnecessary code

### DIFF
--- a/roles/basic-prog-pkgs/tasks/main.yml
+++ b/roles/basic-prog-pkgs/tasks/main.yml
@@ -24,7 +24,7 @@
   loop: "{{ real_users }}"
 # Dest becomes path in Ansible 2.3+
 - name: Set Idle pref in existing mimeapps
-  lineinfile: 
+  lineinfile:
     dest: '{{ item.homedir }}/.config/mimeapps.list'
     regexp: '^text/x-python='
     line: 'text/x-python=idle-python3.6.desktop;gedit.desktop;pluma.desktop'

--- a/roles/oem/tasks/main.yml
+++ b/roles/oem/tasks/main.yml
@@ -5,11 +5,8 @@
   assert:
       that:
         - "ansible_distribution == 'Linuxmint' or ansible_distribution == 'Linux Mint'"
-- name: Update apt cache
-  apt:
-      update_cache: yes
 - include_tasks: vm_only_pre.yml
-  when: "ansible_virtualization_role == 'guest'" 
+  when: "ansible_virtualization_role == 'guest'"
 - name: Remove unused dependencies
   apt:
       autoremove: yes

--- a/roles/user/handlers/main.yml
+++ b/roles/user/handlers/main.yml
@@ -5,7 +5,7 @@
     /usr/bin/update-desktop-database
 - name: Suggest restart
   command: >-
-    notify-send -u critical "JMU Software Change" 
+    notify-send -u critical "JMU Software Change"
     "Changes have been made to your machine that 
     will only take effect when you log out or 
     when you reboot. Please do this immediately."

--- a/roles/user/tasks/main.yml
+++ b/roles/user/tasks/main.yml
@@ -31,7 +31,7 @@
       upgrade: safe
 - name: Install required dependencies
   apt: name={{ user_dependencies }} state=latest
- 
+
 - name: Touch VM profile
   copy:
     src: csvmprofile


### PR DESCRIPTION
Remove duplicate consecutive apt update. Also remove trailing space
to silence a few ansible-lint warnings.

Closes #232 