### PR TITLE
Add checkstyle plugin installation to Eclipse

### DIFF
--- a/roles/eclipse/tasks/main.yml
+++ b/roles/eclipse/tasks/main.yml
@@ -31,6 +31,16 @@
         dest: '{{ global_base_path }}'
         src: '{{ eclipse.zip }}'
   when: st.stat.checksum|default("") != eclipse.hash
+- name: Install checkstyle plugin
+  command: >
+      {{ eclipse.install_path }}/eclipse
+      -nosplash
+      -application org.eclipse.equinox.p2.director
+      -repository http://eclipse-cs.sourceforge.net/update/
+      -installIU net.sf.eclipsecs.feature.group
+      -destination {{ eclipse.install_path }}
+  args:
+    creates: '{{ eclipse.install_path }}/plugins/net.sf.eclipsecs.checkstyle*'
 - name: Install Eclipse desktop icon
   template:
     src: eclipse.desktop.j2


### PR DESCRIPTION
Please give this a try when you get a moment. I think the `creates` argument prevents re-running the install, but I left it outside the usual installation block so people could run the role and add checkstyle to an existing install. If possible, try this on a machine with checkstyle installed to `$HOME/.eclipse` via the usual methods, then see if Eclipse loses its mind with two installs present.

I'll do a backport if so encouraged.