### PR TITLE
Allow apt update to fail

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -72,3 +72,4 @@
   apt:
     update_cache: yes
   changed_when: False
+  ignore_errors: yes

--- a/roles/robot-pkgs/tasks/main.yml
+++ b/roles/robot-pkgs/tasks/main.yml
@@ -15,6 +15,7 @@
 - name: Refresh apt cache
   apt:
     update_cache: yes
+  ignore_errors: yes
 - name: Install robot development packages
   apt: name={{ ros_packages }} state=latest
 - name: Create ROS profile entries


### PR DESCRIPTION
Sorry, this is kind of a 911 PR at the moment.

Through an unfortunate set of circumstances, we've found that Ansible does not allow any mirror to fail when performing an update. This defeats the purpose of keeping the upstream Ubuntu mirror in sources, while preferring the JMU mirror. This allow the playbook to advance to later steps and pull from alternate mirrors.