### PR TITLE
Allow apt update to fail

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -72,3 +72,4 @@
   apt:
     update_cache: yes
   changed_when: False
+  ignore_errors: yes

--- a/roles/robot-pkgs/tasks/main.yml
+++ b/roles/robot-pkgs/tasks/main.yml
@@ -15,6 +15,7 @@
 - name: Refresh apt cache
   apt:
     update_cache: yes
+  ignore_errors: yes
 - name: Install robot development packages
   apt: name={{ ros_packages }} state=latest
 - name: Create ROS profile entries


### PR DESCRIPTION
Ansible does not allow any mirror to fail when performing an update.

Same as #290 