### PR TITLE
Mirror transport

### DIFF
--- a/roles/common/files/mint.mirror
+++ b/roles/common/files/mint.mirror
@@ -1,0 +1,2 @@
+https://mirror.cs.jmu.edu/pub/linuxmint/packages	priority:1
+http://packages.linuxmint.com	priority:2

--- a/roles/common/files/ubuntu.mirror
+++ b/roles/common/files/ubuntu.mirror
@@ -1,0 +1,2 @@
+https://mirror.cs.jmu.edu/pub/ubuntu	priority:1
+http://us.archive.ubuntu.com/ubuntu	priority:2

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -52,6 +52,20 @@
       dest: "{{ icon_path }}/jmucs_config.desktop"
       mode: "{{ file_mode }}"
 
+- name: Install Mint mirror list
+  copy:
+    src: mint.mirror
+    dest: /etc/apt/mint.mirror
+    owner: root
+    group: root
+    mode: 0664
+- name: Install Ubuntu mirror list
+  copy:
+    src: ubuntu.mirror
+    dest: /etc/apt/ubuntu.mirror
+    owner: root
+    group: root
+    mode: 0664
 - name: Set Ubuntu mirrors
   template:
     src: ubuntu.j2
@@ -72,4 +86,3 @@
   apt:
     update_cache: yes
   changed_when: False
-  ignore_errors: yes

--- a/roles/common/templates/mint.j2
+++ b/roles/common/templates/mint.j2
@@ -4,20 +4,12 @@
 # Place modification another file in /etc/apt/sources.list.d/ with a .list
 # file extension.
 
-{% for mirror in ubuntu_mirrors %}
-# Upstream Ubuntu sources for {{ mirror }}
-deb {{ mirror }} {{ ubuntu_release }} main restricted universe multiverse
-deb {{ mirror }} {{ ubuntu_release }}-updates main restricted universe multiverse
-deb {{ mirror }} {{ ubuntu_release }}-backports main restricted universe multiverse
-deb {{ mirror }} {{ ubuntu_release }}-security main restricted universe multiverse
+deb mirror+file:/etc/apt/ubuntu.mirror {{ ubuntu_release }} main restricted universe multiverse
+deb mirror+file:/etc/apt/ubuntu.mirror {{ ubuntu_release }}-updates main restricted universe multiverse
+deb mirror+file:/etc/apt/ubuntu.mirror {{ ubuntu_release }}-backports main restricted universe multiverse
+deb mirror+file:/etc/apt/ubuntu.mirror {{ ubuntu_release }}-security main restricted universe multiverse
 
-{% endfor %}
-
-{% for mirror in mint_mirrors %}
-# Mint sources for {{ mirror }}
-deb {{ mirror }} {{ ansible_distribution_release }} main upstream import backport
-
-{% endfor %}
+deb mirror+file:/etc/apt/mint.mirror {{ ansible_distribution_release }} main upstream import backport
 
 # Parter repository (necessary for optional media codecs)
 deb http://archive.canonical.com/ubuntu bionic partner

--- a/roles/common/templates/ubuntu.j2
+++ b/roles/common/templates/ubuntu.j2
@@ -4,13 +4,10 @@
 # Place modification another file in /etc/apt/sources.list.d/ with a .list
 # file extension.
 
-{% for mirror in ubuntu_mirrors %}
-deb {{ mirror }} {{ ubuntu_release }} main restricted universe multiverse
-deb {{ mirror }} {{ ubuntu_release }}-updates main restricted universe multiverse
-deb {{ mirror }} {{ ubuntu_release }}-backports main restricted universe multiverse
-deb {{ mirror }} {{ ubuntu_release }}-security main restricted universe multiverse
-
-{% endfor %}
+deb mirror+file:/etc/apt/ubuntu.mirror {{ ubuntu_release }} main restricted universe multiverse
+deb mirror+file:/etc/apt/ubuntu.mirror {{ ubuntu_release }}-updates main restricted universe multiverse
+deb mirror+file:/etc/apt/ubuntu.mirror {{ ubuntu_release }}-backports main restricted universe multiverse
+deb mirror+file:/etc/apt/ubuntu.mirror {{ ubuntu_release }}-security main restricted universe multiverse
 
 # Parter repository (necessary for optional media codecs)
 deb http://archive.canonical.com/ubuntu bionic partner

--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -1,9 +1,2 @@
 ---
 # vars file for common
-ubuntu_mirrors:
-  - "https://mirror.cs.jmu.edu/pub/ubuntu"
-  - "http://us.archive.ubuntu.com/ubuntu"
-
-mint_mirrors:
-  - "https://mirror.cs.jmu.edu/pub/linuxmint/packages"
-  - "http://packages.linuxmint.com"

--- a/roles/robot-pkgs/files/robot.mirror
+++ b/roles/robot-pkgs/files/robot.mirror
@@ -1,0 +1,2 @@
+http://mirror.umd.edu/packages.ros.org/ros/ubuntu	priority:1
+http://packages.ros.org/ros/ubuntu	priority:2

--- a/roles/robot-pkgs/tasks/main.yml
+++ b/roles/robot-pkgs/tasks/main.yml
@@ -5,6 +5,13 @@
     keyserver: ha.pool.sks-keyservers.net
     id: 421C365BD9FF1F717815A3895523BAEEB01FA116
     state: present
+- name: Install Robot mirror list
+  copy:
+    src: robot.mirror
+    dest: /etc/apt/robot.mirror
+    owner: root
+    group: root
+    mode: 0644
 - name: Add ROS repository
   template:
     src: ros-packages.j2
@@ -15,7 +22,6 @@
 - name: Refresh apt cache
   apt:
     update_cache: yes
-  ignore_errors: yes
 - name: Install robot development packages
   apt: name={{ ros_packages }} state=latest
 - name: Create ROS profile entries

--- a/roles/robot-pkgs/templates/ros-packages.j2
+++ b/roles/robot-pkgs/templates/ros-packages.j2
@@ -1,6 +1,3 @@
 # Upstream repos for ROS packages
 
-{%for mirror in ros_repos %}
-deb {{ mirror }} {{ ubuntu_release }} main
-
-{% endfor %}
+deb mirror+file:/etc/apt/robot.mirror {{ ubuntu_release }} main

--- a/roles/robot-pkgs/vars/main.yml
+++ b/roles/robot-pkgs/vars/main.yml
@@ -2,11 +2,6 @@
 # vars file for robot-pkgs
 ros_release: melodic
 
-# Keep UMD first to prefer downloads from there
-ros_repos:
-  - "http://mirror.umd.edu/packages.ros.org/ros/ubuntu"
-  - "http://packages.ros.org/ros/ubuntu"
-
 ros_packages:
     - ros-{{ros_release}}-desktop-full
     - ros-{{ros_release}}-sound-play


### PR DESCRIPTION
Here's an attempt at #292. Apt has a "mirror transport" instead of http/https. In brief testing, it appears to allow more explicit configuration of mirror priority, and Ansible doesn't trip over itself when a mirror is unavailable.

If merged, closes #292 