### PR TITLE
Update ROS apt-key and URL

### DIFF
--- a/roles/robot-pkgs/tasks/main.yml
+++ b/roles/robot-pkgs/tasks/main.yml
@@ -2,8 +2,8 @@
 # tasks file for robot-pkgs
 - name: Add ROS key
   apt_key:
-    keyserver: ha.pool.sks-keyservers.net
-    id: 421C365BD9FF1F717815A3895523BAEEB01FA116
+    id: C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+    url: http://packages.ros.org/ros.asc
     state: present
 - name: Add ROS repository
   template:


### PR DESCRIPTION
Opened in favor of #303 

Changes:
* Updated the key, since the ROS folks recently released a new GPG key that deprecates the old one.
Link documenting the change: [https://discourse.ros.org/t/new-gpg-keys-deployed-for-packages-ros-org/9454](https://discourse.ros.org/t/new-gpg-keys-deployed-for-packages-ros-org/9454)
* Change `keyserver` parameter to `url` parameter to avoid using the SKS keyserver pool as @kylelaker sugested

closes #302 