### PR TITLE
Add VSCode support for CS149

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -15,3 +15,4 @@
     - { role: finch, tags: ["cs101"] }
     - { role: y86, tags: ["cs261"] }
     - { role: programming-langs, tags: ["cs430"] }
+    - { role: vscode, tags: ["cs149"] }

--- a/roles/vscode/README.md
+++ b/roles/vscode/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+MIT
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/roles/vscode/defaults/main.yml
+++ b/roles/vscode/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for vscode

--- a/roles/vscode/handlers/main.yml
+++ b/roles/vscode/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for vscode

--- a/roles/vscode/meta/main.yml
+++ b/roles/vscode/meta/main.yml
@@ -1,0 +1,21 @@
+---
+galaxy_info:
+  author: Unix Users Group
+  description: Installs VSCode and recommended extensions for CS149
+  company: James Madison University
+  license: MIT
+  min_ansible_version: 2.1
+  github_branch: master
+  platforms:
+    - name: Ubuntu
+      versions:
+      - bionic
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+# TODO Add common as a dependency
+dependencies: []

--- a/roles/vscode/tasks/main.yml
+++ b/roles/vscode/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+# tasks file for vscode
+- name: Add Microsoft key
+  apt_key:
+    id: BC528686B50D79E339D3721CEB3E94ADBE1229CF
+    url: https://packages.microsoft.com/keys/microsoft.asc
+    state: present
+- name: Install VSCode Repository file
+  apt_repository:
+    repo: deb https://packages.microsoft.com/repos/vscode stable main
+    state: present
+    filename: vscode
+- name: Install VSCode
+  apt:
+    name: 'code'
+    state: latest
+- name: Install Java pack plugin
+  command: /usr/bin/code --install-extension vscjava.vscode-java-pack
+  args:
+    creates: '{{ item.homedir }}/.vscode/extensions/vscjava.vscode-java-pack*'
+  become: yes
+  become_user: "{{ item.user }}"
+  loop: "{{ real_users }}"
+- name: Install checkstyle plugin
+  command: /usr/bin/code --install-extension shengchen.vscode-checkstyle
+  args:
+    creates: '{{ item.homedir }}/.vscode/extensions/shengchen.vscode-checkstyle*'
+  become: yes
+  become_user: "{{ item.user }}"
+  loop: "{{ real_users }}"

--- a/roles/vscode/tests/inventory
+++ b/roles/vscode/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/vscode/tests/test.yml
+++ b/roles/vscode/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - vscode

--- a/roles/vscode/vars/main.yml
+++ b/roles/vscode/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for vscode


### PR DESCRIPTION
Adds Microsoft key and repo, installs Code, and adds Java/Checkstyle plugins per user. Like Eclipse, it leaves a checkstyle.xml configuration to the user.

Closes #315 