### PR TITLE
Force all pending dpkg operations to complete

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -24,6 +24,10 @@
   set_fact:
     ubuntu_release: "{{ lookup('ini', 'UBUNTU_CODENAME type=properties file=/etc/os-release') }}"
 
+- name: Process all pending installs
+  command: /usr/bin/dpkg --configure -a
+  register: dpkg_command
+  changed_when: dpkg_command.stdout
 - name: Create VMTools bin
   file:
     path: "{{ bin_path }}"

--- a/roles/user/tasks/main.yml
+++ b/roles/user/tasks/main.yml
@@ -28,7 +28,7 @@
     - item.value.5 != "/usr/sbin/nologin"
 - name: Upgrade installed software
   apt:
-      upgrade: safe
+    upgrade: full
 - name: Install required dependencies
   apt: name={{ user_dependencies }} state=latest
 


### PR DESCRIPTION
This should force packages that are half-installed to be finished before we attempt anything else. If there's nothing pending, this should be a no-op. Thought about querying for stuck packages and only doing this if absolutely necessary, but decided it wasn't worth the effort, since it will silently proceed if everything if fine.

Closes #314 