### PR TITLE
Set non-interactive mode for dpkg

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -28,6 +28,8 @@
   command: /usr/bin/dpkg --configure -a
   register: dpkg_command
   changed_when: dpkg_command.stdout
+  environment:
+    DEBIAN_FRONTEND: noninteractive
 - name: Create VMTools bin
   file:
     path: "{{ bin_path }}"


### PR DESCRIPTION
Not sure this is sufficient for #321, but I'm hoping it helps. Probably should have been done in the first place.