### PR TITLE
Put local copy of repository in /tmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ ansible-playbook -i hosts -c local -K -t TAGS local.yml
 or directly from GitHub:
 
 ```
-ansible-pull -U https://github.com/jmunixusers/cs-vm-build --purge -i hosts -K -t TAGS
+ansible-pull -U https://github.com/jmunixusers/cs-vm-build --directory /tmp --purge -i hosts -K -t TAGS
 ```
 where TAGS is a comma separated list (with no spaces) of
 cs101, cs149, cs159, cs261, cs354, and/or cs361 as appropriate.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ ansible-playbook -i hosts -c local -K -t TAGS local.yml
 or directly from GitHub:
 
 ```
-ansible-pull -U https://github.com/jmunixusers/cs-vm-build --directory /tmp --purge -i hosts -K -t TAGS
+ansible-pull -U https://github.com/jmunixusers/cs-vm-build --directory /tmp/cs-vm-build --purge -i hosts -K -t TAGS
 ```
 where TAGS is a comma separated list (with no spaces) of
 cs101, cs149, cs159, cs261, cs354, and/or cs361 as appropriate.

--- a/roles/common/files/uug_ansible_wrapper.py
+++ b/roles/common/files/uug_ansible_wrapper.py
@@ -426,6 +426,8 @@ class AnsibleWrapperWindow(Gtk.Window):
             USER_CONFIG['git_url'],
             '--checkout',
             USER_CONFIG['git_branch'],
+            '--directory',
+            '/tmp',
             '--purge',
             '--inventory',
             'hosts',

--- a/roles/common/files/uug_ansible_wrapper.py
+++ b/roles/common/files/uug_ansible_wrapper.py
@@ -430,21 +430,20 @@ class AnsibleWrapperWindow(Gtk.Window):
                 USER_CONFIG['git_branch'],
                 '--directory',
                 temp_dir,
-                '--purge',
                 '--inventory',
                 'hosts',
                 '--tags',
                 ",".join(USER_CONFIG['roles_this_run']),
             ]
 
-        try:
-            self.terminal.spawn_sync(
-                Vte.PtyFlags.DEFAULT, os.environ['HOME'], cmd_args, [],
-                GLib.SpawnFlags.DO_NOT_REAP_CHILD, None, None
-            )
-        except GLib.Error as error:
-            logging.error("Unable to run ansible command.", exc_info=error)
-            self.sub_command_exited(None, 1)
+            try:
+                self.terminal.spawn_sync(
+                    Vte.PtyFlags.DEFAULT, os.environ['HOME'], cmd_args, [],
+                    GLib.SpawnFlags.DO_NOT_REAP_CHILD, None, None
+                )
+            except GLib.Error as error:
+                logging.error("Unable to run ansible command.", exc_info=error)
+                self.sub_command_exited(None, 1)
 
 
 def on_dialog_close(action, _):

--- a/roles/common/files/uug_ansible_wrapper.py
+++ b/roles/common/files/uug_ansible_wrapper.py
@@ -12,6 +12,7 @@ import os
 import re
 import subprocess
 import urllib.request
+from tempfile import TemporaryDirectory
 
 import json
 
@@ -418,22 +419,23 @@ class AnsibleWrapperWindow(Gtk.Window):
             ",".join(USER_CONFIG['roles_this_run'])
         )
 
-        # spawn_sync will not perform a path lookup; however, pkexec will
-        cmd_args = [
-            '/usr/bin/pkexec',
-            'ansible-pull',
-            '--url',
-            USER_CONFIG['git_url'],
-            '--checkout',
-            USER_CONFIG['git_branch'],
-            '--directory',
-            '/tmp',
-            '--purge',
-            '--inventory',
-            'hosts',
-            '--tags',
-            ",".join(USER_CONFIG['roles_this_run']),
-        ]
+        with TemporaryDirectory() as temp_dir:
+            # spawn_sync will not perform a path lookup; however, pkexec will
+            cmd_args = [
+                '/usr/bin/pkexec',
+                'ansible-pull',
+                '--url',
+                USER_CONFIG['git_url'],
+                '--checkout',
+                USER_CONFIG['git_branch'],
+                '--directory',
+                temp_dir,
+                '--purge',
+                '--inventory',
+                'hosts',
+                '--tags',
+                ",".join(USER_CONFIG['roles_this_run']),
+            ]
 
         try:
             self.terminal.spawn_sync(


### PR DESCRIPTION
After a restart, the local copy of the playbook repository will be erased.

We may wish to add --clean as well, so I'm open to suggestions.

Resolves #323 