### PR TITLE
Validate checksum after all downloads

### DIFF
--- a/roles/eclipse/tasks/main.yml
+++ b/roles/eclipse/tasks/main.yml
@@ -11,6 +11,7 @@
       get_url:
         url: '{{ eclipse.url }}'
         dest: '{{ eclipse.zip }}'
+        checksum: 'sha1:{{ eclipse.hash }}'
         timeout: 30
         force: yes
       register: url_output
@@ -19,6 +20,7 @@
       get_url:
         url: '{{ eclipse.url_backup }}'
         dest: '{{ eclipse.zip }}'
+        checksum: 'sha1:{{ eclipse.hash }}'
         timeout: 30
         force: yes
       when: url_output.failed

--- a/roles/finch/tasks/main.yml
+++ b/roles/finch/tasks/main.yml
@@ -13,6 +13,7 @@
       get_url:
         url: '{{ finch.url }}'
         dest: '{{ finch.zip }}'
+        checksum: 'sha1:{{ finch.hash }}'
         force: yes
     - name: Unpack Finch zip
       unarchive:

--- a/roles/jgrasp/tasks/main.yml
+++ b/roles/jgrasp/tasks/main.yml
@@ -13,6 +13,7 @@
       get_url:
         url: '{{ jgrasp.url }}'
         dest: '{{ jgrasp.zip }}'
+        checksum: 'sha1:{{ jgrasp.hash }}'
         force: yes
     - name: Remove old jGRASP directory
       file:


### PR DESCRIPTION
This adds a checksum check to all `get_url` downloads. Possibly unnecessary, but ensures the download was successful and correct.