### PR TITLE
Fix typo in config tool name

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -21,7 +21,7 @@
     bin_path: '{{ base_path }}/vmtools/bin'
 - name: Set wrapper fact
   set_fact:
-    uug_ansible_wrapper: '{{ bin_path }}/uug_ansible_wrapper'
+    uug_ansible_wrapper: '{{ bin_path }}/uug_ansible_wrapper.py'
 - name: Check Ubuntu release
   set_fact:
     ubuntu_release: "{{ lookup('ini', 'UBUNTU_CODENAME type=properties file=/etc/os-release') }}"


### PR DESCRIPTION
Minor issue from #331 that could result in multiple versions of the script being installed. Never was backported. Not really worth the effort to add a task to clean up old stuff because it never was in a real release and any future pulls will switch to using the correct one.