### PR TITLE
Add initial support for Github Actions Beta

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+---
+name: Lint workflow
+on: [pull_request]
+jobs:
+  Lint:
+    name: Run Lint tests
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install ansible-lint yamllint
+    - name: Run ansible-lint
+      run: |
+        ansible-lint local.yml oem.yml
+    - name: Run top-level yamllint
+      run: |
+        yamllint *yml
+    - name: Run role-level yamllint
+      run: |
+        yamllint roles/*/*/*yml


### PR DESCRIPTION
This adds support for Github's Action Beta to do lint testing on pull requests.
This may be subject to change as Github refines action support, but let's add it anyway.
Ripley has a branch that cleans up the rest of the lint requirements.
