### PR TITLE
Clean up yamllint formatting complaints

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,10 @@
+---
+extends: default
+
+rules:
+  braces:
+    min-spaces-inside: 1
+    max-spaces-inside: 1
+  line-length: disable
+  truthy:                                                                       
+    allowed-values: ["yes", "no", "true", "false"]

--- a/roles/adv-prog-pkgs/meta/main.yml
+++ b/roles/adv-prog-pkgs/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: Unix Users Group
-  description: Installs the advanced programming packages generally used in CS261
+  description: Installs the advanced programming packages mostly used in CS261
   company: James Madison University
   license: MIT
   min_ansible_version: 2.1
@@ -9,13 +9,13 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-      - bionic
+        - bionic
   galaxy_tags: []
-    # List tags for your role here, one per line. A tag is a keyword that describes
-    # and categorizes the role. Users find roles by searching for tags. Be sure to
-    # remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-    #       Maximum 20 tags per role.
-# TODO Add common as a dependency
+  # List tags for your role here, one per line. A tag is a keyword that
+  # describes and categorizes the role. Users find roles by searching for tags.
+  # Be sure to remove the '[]' above, if you add tags to this list.
+  #
+  # NOTE: A tag is limited to a single word comprised of alphanumeric
+  # characters. Maximum 20 tags per role.
 dependencies: []
+# TODO Add user as a dependency

--- a/roles/basic-prog-pkgs/meta/main.yml
+++ b/roles/basic-prog-pkgs/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: Unix Users Group
-  description: Installs the basic programming packages used throughout the CS program
+  description: Installs introductory programming packages
   company: James Madison University
   license: MIT
   min_ansible_version: 2.1
@@ -9,13 +9,13 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-      - bionic
+        - bionic
   galaxy_tags: []
-    # List tags for your role here, one per line. A tag is a keyword that describes
-    # and categorizes the role. Users find roles by searching for tags. Be sure to
-    # remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-    #       Maximum 20 tags per role.
-# TODO Add common as a dependency
+  # List tags for your role here, one per line. A tag is a keyword that
+  # describes and categorizes the role. Users find roles by searching for tags.
+  # Be sure to remove the '[]' above, if you add tags to this list.
+  #
+  # NOTE: A tag is limited to a single word comprised of alphanumeric
+  # characters. Maximum 20 tags per role.
 dependencies: []
+# TODO Add user as a dependency

--- a/roles/common/meta/main.yml
+++ b/roles/common/meta/main.yml
@@ -9,14 +9,13 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-      - bionic
+        - bionic
   galaxy_tags: []
-    # List tags for your role here, one per line. A tag is a keyword that describes
-    # and categorizes the role. Users find roles by searching for tags. Be sure to
-    # remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-    #       Maximum 20 tags per role.
-#TODO Add common as a dependency
+  # List tags for your role here, one per line. A tag is a keyword that
+  # describes and categorizes the role. Users find roles by searching for tags.
+  # Be sure to remove the '[]' above, if you add tags to this list.
+  #
+  # NOTE: A tag is limited to a single word comprised of alphanumeric
+  # characters. Maximum 20 tags per role.
 dependencies: []
-
+# TODO Add user as a dependency

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -83,5 +83,5 @@
 - name: Refresh apt cache
   apt:
     update_cache: yes
-  changed_when: False
+  changed_when: false
   ignore_errors: yes

--- a/roles/eclipse/meta/main.yml
+++ b/roles/eclipse/meta/main.yml
@@ -9,13 +9,13 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-      - bionic
+        - bionic
   galaxy_tags: []
-    # List tags for your role here, one per line. A tag is a keyword that describes
-    # and categorizes the role. Users find roles by searching for tags. Be sure to
-    # remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-    #       Maximum 20 tags per role.
-# TODO Add common as a dependency
+  # List tags for your role here, one per line. A tag is a keyword that
+  # describes and categorizes the role. Users find roles by searching for tags.
+  # Be sure to remove the '[]' above, if you add tags to this list.
+  #
+  # NOTE: A tag is limited to a single word comprised of alphanumeric
+  # characters. Maximum 20 tags per role.
 dependencies: []
+# TODO Add user as a dependency

--- a/roles/filezilla/meta/main.yml
+++ b/roles/filezilla/meta/main.yml
@@ -9,13 +9,13 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-      - bionic
+        - bionic
   galaxy_tags: []
-    # List tags for your role here, one per line. A tag is a keyword that describes
-    # and categorizes the role. Users find roles by searching for tags. Be sure to
-    # remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-    #       Maximum 20 tags per role.
-# TODO Add common as a dependency
+  # List tags for your role here, one per line. A tag is a keyword that
+  # describes and categorizes the role. Users find roles by searching for tags.
+  # Be sure to remove the '[]' above, if you add tags to this list.
+  #
+  # NOTE: A tag is limited to a single word comprised of alphanumeric
+  # characters. Maximum 20 tags per role.
 dependencies: []
+# TODO Add user as a dependency

--- a/roles/finch/meta/main.yml
+++ b/roles/finch/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: Unix Users Group
-  description: Installs the tools and scripts needed to use the Finch robots in CS101
+  description: Installs the tools and scripts needed to use Finch robots
   company: James Madison University
   license: MIT
   min_ansible_version: 2.1
@@ -9,13 +9,13 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-      - bionic
+        - bionic
   galaxy_tags: []
-    # List tags for your role here, one per line. A tag is a keyword that describes
-    # and categorizes the role. Users find roles by searching for tags. Be sure to
-    # remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-    #       Maximum 20 tags per role.
-# TODO Add common as a dependency
+  # List tags for your role here, one per line. A tag is a keyword that
+  # describes and categorizes the role. Users find roles by searching for tags.
+  # Be sure to remove the '[]' above, if you add tags to this list.
+  #
+  # NOTE: A tag is limited to a single word comprised of alphanumeric
+  # characters. Maximum 20 tags per role.
 dependencies: []
+# TODO Add user as a dependency

--- a/roles/jgrasp/meta/main.yml
+++ b/roles/jgrasp/meta/main.yml
@@ -9,13 +9,13 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-      - bionic
+        - bionic
   galaxy_tags: []
-    # List tags for your role here, one per line. A tag is a keyword that describes
-    # and categorizes the role. Users find roles by searching for tags. Be sure to
-    # remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-    #       Maximum 20 tags per role.
-# TODO Add common as a dependency
+  # List tags for your role here, one per line. A tag is a keyword that
+  # describes and categorizes the role. Users find roles by searching for tags.
+  # Be sure to remove the '[]' above, if you add tags to this list.
+  #
+  # NOTE: A tag is limited to a single word comprised of alphanumeric
+  # characters. Maximum 20 tags per role.
 dependencies: []
+# TODO Add user as a dependency

--- a/roles/oem/meta/main.yml
+++ b/roles/oem/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: Unix Users Group
-  description: Performs the configuration necessary on the VM before it is distributed
+  description: Performs the configuration necessary before VM distribution
   company: James Madison University
   license: MIT
   min_ansible_version: 2.1
@@ -9,13 +9,13 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-      - bionic
+        - bionic
   galaxy_tags: []
-    # List tags for your role here, one per line. A tag is a keyword that describes
-    # and categorizes the role. Users find roles by searching for tags. Be sure to
-    # remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-    #       Maximum 20 tags per role.
-# TODO Add common as a dependency
+  # List tags for your role here, one per line. A tag is a keyword that
+  # describes and categorizes the role. Users find roles by searching for tags.
+  # Be sure to remove the '[]' above, if you add tags to this list.
+  #
+  # NOTE: A tag is limited to a single word comprised of alphanumeric
+  # characters. Maximum 20 tags per role.
 dependencies: []
+# TODO Add user as a dependency

--- a/roles/oem/tasks/vm_only_post.yml
+++ b/roles/oem/tasks/vm_only_post.yml
@@ -18,19 +18,19 @@
 - name: Clean the apt database
   command: apt-get clean
   # This will always report as changed otherwise
-  changed_when: False
+  changed_when: false
   args:
     warn: no
 
 # The USB 2/3 controllers are only available with the Virtualbox
 # Extensions which are non-free software and available only under the Oracle
 # PUEL. We should ensure we have not accidentally included them.
-- name: Validate missing USB 2/3 controllers # noqa 306
+- name: Validate missing USB 2/3 controllers  # noqa 306
   command: lspci
   register: lspci_output
   failed_when: "'ECHI' in lspci_output.stdout or 'xHCI' in lspci_output.stdout"
-  changed_when: False
+  changed_when: false
 
 - name: Fill disk with zeros to assist with compression
   shell: dd if=/dev/zero of=/bigfile bs=1M; sync; rm /bigfile
-  changed_when: False
+  changed_when: false

--- a/roles/programming-langs/meta/main.yml
+++ b/roles/programming-langs/meta/main.yml
@@ -9,13 +9,13 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-      - bionic
+        - bionic
   galaxy_tags: []
-    # List tags for your role here, one per line. A tag is a keyword that describes
-    # and categorizes the role. Users find roles by searching for tags. Be sure to
-    # remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-    #       Maximum 20 tags per role.
-# TODO Add user as a dependency
+  # List tags for your role here, one per line. A tag is a keyword that
+  # describes and categorizes the role. Users find roles by searching for tags.
+  # Be sure to remove the '[]' above, if you add tags to this list.
+  #
+  # NOTE: A tag is limited to a single word comprised of alphanumeric
+  # characters. Maximum 20 tags per role.
 dependencies: []
+# TODO Add user as a dependency

--- a/roles/robot-pkgs/meta/main.yml
+++ b/roles/robot-pkgs/meta/main.yml
@@ -9,13 +9,13 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-      - bionic
+        - bionic
   galaxy_tags: []
-    # List tags for your role here, one per line. A tag is a keyword that describes
-    # and categorizes the role. Users find roles by searching for tags. Be sure to
-    # remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-    #       Maximum 20 tags per role.
-# TODO Add common as a dependency
+  # List tags for your role here, one per line. A tag is a keyword that
+  # describes and categorizes the role. Users find roles by searching for tags.
+  # Be sure to remove the '[]' above, if you add tags to this list.
+  #
+  # NOTE: A tag is limited to a single word comprised of alphanumeric
+  # characters. Maximum 20 tags per role.
 dependencies: []
+# TODO Add user as a dependency

--- a/roles/robot-pkgs/tasks/main.yml
+++ b/roles/robot-pkgs/tasks/main.yml
@@ -33,7 +33,7 @@
   command: rosdep init
   args:
     creates: /etc/ros/rosdep/sources.list.d/20-default.list
-- name: Update rosdep for each user # noqa 301
+- name: Update rosdep for each user  # noqa 301
   command: rosdep update
   become: yes
   become_user: "{{ item.user }}"
@@ -75,7 +75,7 @@
   shell: lspci | grep -i -e EHCI -e xHCI
   register: lspci_output
   ignore_errors: yes
-  changed_when: False
+  changed_when: false
 - name: Alert missing USB 2/3 controllers
   # Something must be executed or Ansible errors
   command: /bin/true

--- a/roles/user/meta/main.yml
+++ b/roles/user/meta/main.yml
@@ -9,13 +9,13 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-      - bionic
+        - bionic
   galaxy_tags: []
-    # List tags for your role here, one per line. A tag is a keyword that describes
-    # and categorizes the role. Users find roles by searching for tags. Be sure to
-    # remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-    #       Maximum 20 tags per role.
-# TODO Add user as a dependency
+  # List tags for your role here, one per line. A tag is a keyword that
+  # describes and categorizes the role. Users find roles by searching for tags.
+  # Be sure to remove the '[]' above, if you add tags to this list.
+  #
+  # NOTE: A tag is limited to a single word comprised of alphanumeric
+  # characters. Maximum 20 tags per role.
 dependencies: []
+# TODO Add user as a dependency

--- a/roles/user/tasks/main.yml
+++ b/roles/user/tasks/main.yml
@@ -11,8 +11,8 @@
 - name: Get users
   getent:
     database: passwd
- # fix this after Ansible 2.6, use loop: "{{ getent_passwd|dict2items }}"
 - name: Build real user list
+  # fix this after Ansible 2.6, use loop: "{{ getent_passwd|dict2items }}"
   set_fact:
     real_users: >-
       {{ real_users|default([]) +

--- a/roles/vscode/meta/main.yml
+++ b/roles/vscode/meta/main.yml
@@ -9,13 +9,13 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-      - bionic
+        - bionic
   galaxy_tags: []
-    # List tags for your role here, one per line. A tag is a keyword that describes
-    # and categorizes the role. Users find roles by searching for tags. Be sure to
-    # remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-    #       Maximum 20 tags per role.
-# TODO Add common as a dependency
+  # List tags for your role here, one per line. A tag is a keyword that
+  # describes and categorizes the role. Users find roles by searching for tags.
+  # Be sure to remove the '[]' above, if you add tags to this list.
+  #
+  # NOTE: A tag is limited to a single word comprised of alphanumeric
+  # characters. Maximum 20 tags per role.
 dependencies: []
+# TODO Add user as a dependency

--- a/roles/wireless-printing/meta/main.yml
+++ b/roles/wireless-printing/meta/main.yml
@@ -9,13 +9,13 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-      - bionic
+        - bionic
   galaxy_tags: []
-    # List tags for your role here, one per line. A tag is a keyword that describes
-    # and categorizes the role. Users find roles by searching for tags. Be sure to
-    # remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-    #       Maximum 20 tags per role.
-# TODO Add common as a dependency
+  # List tags for your role here, one per line. A tag is a keyword that
+  # describes and categorizes the role. Users find roles by searching for tags.
+  # Be sure to remove the '[]' above, if you add tags to this list.
+  #
+  # NOTE: A tag is limited to a single word comprised of alphanumeric
+  # characters. Maximum 20 tags per role.
 dependencies: []
+# TODO Add user as a dependency

--- a/roles/y86/meta/main.yml
+++ b/roles/y86/meta/main.yml
@@ -9,13 +9,13 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-      - bionic
+        - bionic
   galaxy_tags: []
-    # List tags for your role here, one per line. A tag is a keyword that describes
-    # and categorizes the role. Users find roles by searching for tags. Be sure to
-    # remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-    #       Maximum 20 tags per role.
-# TODO Add common as a dependency
+  # List tags for your role here, one per line. A tag is a keyword that
+  # describes and categorizes the role. Users find roles by searching for tags.
+  # Be sure to remove the '[]' above, if you add tags to this list.
+  #
+  # NOTE: A tag is limited to a single word comprised of alphanumeric
+  # characters. Maximum 20 tags per role.
 dependencies: []
+# TODO Add user as a dependency


### PR DESCRIPTION
This cleans up remaining yamllint errors without breaking ansible-lint. Mostly formatting, including capitalization, reflowing lines to < 80, and tweaking wording.

Admittedly, this skips out on fixing all "truthy" values to true/false or yes/no, by accepting any of the four. These could likely be fixed, but should be reviewed on a per-module basis. This at least closes the gap between what we have, and a yamllint config, and will prevent regressions going forward, with Actions in place.