### PR TITLE
Remove IDE controller during VM creation

### DIFF
--- a/packer/oem-build.json
+++ b/packer/oem-build.json
@@ -39,6 +39,7 @@
         ["modifyvm", "{{.Name}}", "--usb", "on", "--usbehci", "off", "--usbxhci", "off" ],
         ["modifyvm", "{{.Name}}", "--vram", "64" ],
         ["modifyvm", "{{.Name}}", "--vrde", "off" ],
+        ["storagectl", "{{.Name}}", "--name", "IDE Controller", "--remove" ],
         ["storagectl", "{{.Name}}", "--name", "SATA Controller", "--hostiocache", "on" ]
       ],
 


### PR DESCRIPTION
Turns out, the IDE controller wasn't needed. We already have a SATA CD, and the initial additions installation is done by uploading the iso over sftp.

Closes #309 