### PR TITLE
Add custom mintreport script

### DIFF
--- a/roles/common/files/CustomMintReportInfo.py
+++ b/roles/common/files/CustomMintReportInfo.py
@@ -1,0 +1,42 @@
+import os
+import gettext
+import gi
+import subprocess
+
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
+
+from mintreport import InfoReport, InfoReportAction
+
+class Report(InfoReport):
+
+    def __init__(self):
+
+        self.title = "Run JMU CS Config Tool"
+        self.icon = "edu.jmu.uug.tux"
+        self.has_ignore_button = False
+
+    def is_pertinent(self):
+        return not os.path.exists('/opt/csvmprofile')
+
+    def get_descriptions(self):
+        # Return the descriptions
+        descriptions = []
+        descriptions.append("The JMU CS Config Tool has not been run on this machine yet.")
+        descriptions.append("The config tool allows you to install software and customizations for specific JMU CS courses while also ensuring your machine is up-to-date.")
+        return descriptions
+
+    def get_actions(self):
+        # Return available actions
+        actions = []
+        action = InfoReportAction(label="Run tool", callback=self.callback)
+        action.set_style(Gtk.STYLE_CLASS_SUGGESTED_ACTION)
+        actions.append(action)
+        return actions
+
+    def callback(self, data):
+        subprocess.run(["/opt/vmtools/bin/uug_ansible_wrapper.py"], start_new_session=True)
+        return True
+
+if __name__ == "__main__":
+    report = Report()

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -58,11 +58,34 @@
     src: jmu-tux.svg
     dest: "{{ base_path }}/jmu-tux.svg"
     mode: 0644
+- name: Install JMU Tux globally
+  copy:
+    src: jmu-tux.svg
+    dest: "/usr/share/icons/hicolor/scalable/apps/edu.jmu.uug.tux.svg"
+    mode: 0644
+- name: Update icon cache
+  command: /usr/sbin/update-icon-caches /usr/share/icons/*
 - name: Copy shortcut to desktop file directory
   template:
     src: desktop-template.desktop.j2
     dest: "{{ icon_path }}/jmucs_config.desktop"
     mode: "{{ file_mode }}"
+- name: Create directory for custom MintReport script
+  file:
+    path: /usr/share/linuxmint/mintreport/reports/001_Run-JMU-CS-Config-Tool
+    mode: 0755
+    owner: root
+    group: root
+    state: directory
+  when: ansible_distribution == "Linux Mint"
+- name: Install custom MintReport script
+  copy:
+    src: CustomMintReportInfo.py
+    dest: /usr/share/linuxmint/mintreport/reports/001_Run-JMU-CS-Config-Tool/MintReportInfo.py
+    mode: 0644
+    owner: root
+    group: root
+  when: ansible_distribution == "Linux Mint"
 
 - name: Set Ubuntu mirrors
   template:

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -63,8 +63,9 @@
     src: jmu-tux.svg
     dest: "/usr/share/icons/hicolor/scalable/apps/edu.jmu.uug.tux.svg"
     mode: 0644
-  # noqa 301
-- name: Update icon cache
+  # Check 301 is disabled since there isn't a good way to verify whether or not the
+  # database changed during the update.
+- name: Update icon cache  # noqa 301
   command: /usr/sbin/update-icon-caches /usr/share/icons/*
 - name: Copy shortcut to desktop file directory
   template:

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -63,6 +63,7 @@
     src: jmu-tux.svg
     dest: "/usr/share/icons/hicolor/scalable/apps/edu.jmu.uug.tux.svg"
     mode: 0644
+  # noqa 301
 - name: Update icon cache
   command: /usr/sbin/update-icon-caches /usr/share/icons/*
 - name: Copy shortcut to desktop file directory


### PR DESCRIPTION
This will present a "Detected problem" that can't be ignored if the tool hasn't been run. It's in `common` so it gets included in OEM and so we can add more features in the future (like detecting if there is a newer version available in `git` than what the user last ran). Currently it just checks to see if `/opt/csvmprofile` exists, which is a file created only in `user`, which is a way to detect whether the tool has ever been run.

This will only really have an effect on Mint 19.3 or newer; however, it should not cause any issues on older releases either.