### PR TITLE
Backport update Finch bundle hash, per BirdBrain support

### DIFF
--- a/roles/finch/vars/main.yml
+++ b/roles/finch/vars/main.yml
@@ -3,5 +3,5 @@
 finch:
   url: 'https://www.birdbraintechnologies.com/downloads/finch/FinchPython120.zip'
   zip: '{{ global_base_path }}/FinchPython120.zip'
-  hash: 'dce5cea6562cb4b2c1f2489131227d211d559198'
+  hash: '177345bd2029f8055c53f3f078e90c72ca80c260'
   install_path: '{{ global_base_path }}/FinchPython'


### PR DESCRIPTION
Backport #356 one version