### PR TITLE
Update debconf prefs for grub to install to /dev/sda

### DIFF
--- a/roles/oem/tasks/vm_only_post.yml
+++ b/roles/oem/tasks/vm_only_post.yml
@@ -13,6 +13,20 @@
   notify:
     - Update dconf database
 
+- name: Set debconf grub install_devices
+  debconf:
+    name: grub-pc
+    question: grub-pc/install_devices
+    value: /dev/sda
+    vtype: multiselect
+
+- name: Set debconf grub install_devices_disks_changed
+  debconf:
+    name: grub-pc
+    question: grub-pc/install_devices_disks_changed
+    value: /dev/sda
+    vtype: multiselect
+
 # The apt database can be fairly large and make the image unnecessarily large
 # so removing it before shipping allows us to ship a smaller image.
 - name: Clean the apt database


### PR DESCRIPTION
Going to open this as a draft for conversation, then probably torch it and merge it with the rest of tricia if we agree. Somewhere along the way, I noticed that `grub-pc` package updates will now prompt a user for which disk/partition to install to, which is a terrifying question for a first-time linux user. It seems the Mint setup configures grub to use the SATA serial number of the disk, not the path, and the VBox import/export resets that. This patch would set debconf during OEM to install to /dev/sda for any future grub updates.

The part I'm not sure about is if we should reset it to the current UUID/serial during user stages after import. I suspect we could guard the debconf pref with a `if(hardware == virtualbox && currentsetting == /dev/sda)`, so it would be unlikely to apply on a machine not built by us. I'm also willing to accept the balance of likelihood of us getting that wrong vs a student accidentally attaching a different /dev/sda during a grub update.

Thoughts, @kylelaker, @Advill, or anyone else listening?