### PR TITLE
Update URL and hash for Eclipse 2019-12 release

### DIFF
--- a/roles/eclipse/vars/main.yml
+++ b/roles/eclipse/vars/main.yml
@@ -3,9 +3,9 @@
 eclipse:
   # Ensure the URL does not specify a mirror and that &r=1 is at the end, which
   # directly links to the file and not the web page with a download button
-  url: 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/2019-09/R/eclipse-java-2019-09-R-linux-gtk-x86_64.tar.gz&r=1'
-  url_backup: 'http://mirror.cc.vt.edu/pub/eclipse/technology/epp/downloads/release/2019-09/R/eclipse-java-2019-09-R-linux-gtk-x86_64.tar.gz'
-  hash: 'c9a133beb6a44e0d6467adaaf3a5bf4a448f6433'
+  url: 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/2019-12/R/eclipse-java-2019-12-R-linux-gtk-x86_64.tar.gz&r=1'
+  url_backup: 'http://mirror.cc.vt.edu/pub/eclipse/technology/epp/downloads/release/2019-12/R/eclipse-java-2019-12-R-linux-gtk-x86_64.tar.gz'
+  hash: '8aabce73d3feb11eb00e9417a36524807e339aa4'
   zip: '{{ global_base_path }}/eclipse.tar.gz'
   install_path: '{{ global_base_path }}/eclipse'
 


### PR DESCRIPTION
Need to run this once myself, but should be ok.