### PR TITLE
Add additional package to pre-mintupdate task

### DIFF
--- a/roles/oem/tasks/main.yml
+++ b/roles/oem/tasks/main.yml
@@ -13,7 +13,7 @@
 # Force an update of mintupdate, else it only updates itself on first run
 - name: Update mintupdate package
   apt:
-    name: mintupdate
+    name: "{{ upgrade_pre_mintupdate }}"
     state: latest
 - name: Upgrade all installed packages  # noqa 301
   command: /usr/bin/mintupdate-cli -y upgrade

--- a/roles/oem/vars/main.yml
+++ b/roles/oem/vars/main.yml
@@ -3,6 +3,10 @@
 packages_to_install:
   - zenity
 
+upgrade_pre_mintupdate:
+  - mintupdate
+  - mint-upgrade-info
+
 # https://github.com/jmunixusers/cs-vm-build/issues/11#issuecomment-347015788
 packages_to_remove:
   - bluez*


### PR DESCRIPTION
Trying to build the final image for the semester and realized mintupdate was only updating itself again. Added mint-upgrade-info, and moved to list in case future packages are found.