### PR TITLE
Default microphone off

### DIFF
--- a/packer/oem-build.json
+++ b/packer/oem-build.json
@@ -31,6 +31,7 @@
       "sound": "{{user `audio`}}",
 
       "vboxmanage": [
+        ["modifyvm", "{{.Name}}", "--audioin", "off" ],
         ["modifyvm", "{{.Name}}", "--clipboard-mode", "bidirectional" ],
         ["modifyvm", "{{.Name}}", "--graphicscontroller", "vmsvga" ],
         ["modifyvm", "{{.Name}}", "--mouse", "usbtablet"],


### PR DESCRIPTION
Somewhere around VBox 6.1.2 or 6.1.4 I'm starting to get images built with audio input enabled, making a Windows 10 host warn that the VM is listening to you. This forces that setting off during the build.