### PR TITLE
Update Eclipse to 2020-03 release, and replace stale VT.edu mirror

### DIFF
--- a/roles/eclipse/vars/main.yml
+++ b/roles/eclipse/vars/main.yml
@@ -3,9 +3,9 @@
 eclipse:
   # Ensure the URL does not specify a mirror and that &r=1 is at the end, which
   # directly links to the file and not the web page with a download button
-  url: 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/2019-12/R/eclipse-java-2019-12-R-linux-gtk-x86_64.tar.gz&r=1'
-  url_backup: 'http://mirror.cc.vt.edu/pub/eclipse/technology/epp/downloads/release/2019-12/R/eclipse-java-2019-12-R-linux-gtk-x86_64.tar.gz'
-  hash: '8aabce73d3feb11eb00e9417a36524807e339aa4'
+  url: 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/2020-03/R/eclipse-java-2020-03-R-linux-gtk-x86_64.tar.gz&r=1'
+  url_backup: 'http://mirror.cc.columbia.edu/pub/software/eclipse/technology/epp/downloads/release/2020-03/R/eclipse-java-2020-03-R-linux-gtk-x86_64.tar.gz'
+  hash: '01f7f4bf4efa4b43c620cbee9b805b848d3b919a'
   zip: '{{ global_base_path }}/eclipse.tar.gz'
   install_path: '{{ global_base_path }}/eclipse'
 


### PR DESCRIPTION
Update URL to new 2020-03/4.15 release. VT.edu appears to have ended their Eclipse mirror, so update backup URL to columbia.edu. GATech was also considered, but JMU appears to have a much faster path over Internet2 to Columbia.

Closes #372 