### PR TITLE
Add Ubuntu 20.04 (Focal) support

### DIFF
--- a/.github/workflows/packerlint.yml
+++ b/.github/workflows/packerlint.yml
@@ -27,5 +27,6 @@ jobs:
           unzip -d $HOME/packer $HOME/packer.zip
       - name: Packer validate
         run: |
-          $HOME/packer/pkg/packer_linux_amd64 validate packer/oem-build.json
-          $HOME/packer/pkg/packer_linux_amd64 validate -var-file=packer/beta-vars.json packer/oem-build.json
+          $HOME/packer/pkg/packer_linux_amd64 validate packer/ubuntu-build.json
+          $HOME/packer/pkg/packer_linux_amd64 validate packer/mint-build.json
+          $HOME/packer/pkg/packer_linux_amd64 validate -var-file=packer/beta-vars.json packer/mint-build.json

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@
 
 # Packer-related binaries
 packer/packer_cache/*
-packer/artifacts/*
+packer/artifacts_mint/*
+packer/artifacts_ubuntu/*

--- a/local.yml
+++ b/local.yml
@@ -3,7 +3,7 @@
   hosts: all
   become: true
   roles:
-    - { role: common, tags: always, icon_mode: user }
+    - { role: common, tags: always }
     - { role: user, tags: always }
     - { role: wireless-printing, tags: always }
     - { role: filezilla, tags: always }

--- a/oem.yml
+++ b/oem.yml
@@ -3,5 +3,5 @@
   hosts: all
   become: true
   roles:
-    - { role: common, tags: ["oem"], icon_mode: oem }
+    - { role: common, tags: ["oem"] }
     - { role: oem, tags: ["oem"] }

--- a/packer/mint-build.json
+++ b/packer/mint-build.json
@@ -1,0 +1,118 @@
+{
+  "variables": {
+    "vm_name": "JMU Linux Mint",
+    "semester": "Sp20",
+    "version": "19.3",
+
+    "build_id": "{{isotime \"2006-01-02\"}}",
+
+    "git_repo": "https://github.com/jmunixusers/cs-vm-build",
+    "git_branch": "master",
+
+    "headless": "true",
+    "audio": "pulse",
+
+    "output_dir": "{{pwd}}/artifacts_mint",
+    "mirror_url": "http://mirror.cs.jmu.edu/pub/linuxmint/images/stable/19.3",
+    "iso_file": "linuxmint-19.3-cinnamon-64bit.iso",
+
+    "ssh_user": "oem",
+    "ssh_pass": "oem"
+  },
+  "builders": [
+    {
+      "type": "virtualbox-iso",
+      "headless": "{{user `headless`}}",
+      "http_directory": "http",
+      "vm_name": "{{user `vm_name`}} {{user `semester`}}",
+
+      "cpus": 2,
+      "memory": 4096,
+      "sound": "{{user `audio`}}",
+
+      "vboxmanage": [
+        ["modifyvm", "{{.Name}}", "--audioin", "off" ],
+        ["modifyvm", "{{.Name}}", "--clipboard-mode", "bidirectional" ],
+        ["modifyvm", "{{.Name}}", "--graphicscontroller", "vmsvga" ],
+        ["modifyvm", "{{.Name}}", "--mouse", "usbtablet"],
+        ["modifyvm", "{{.Name}}", "--pae", "on"],
+        ["modifyvm", "{{.Name}}", "--rtcuseutc", "on"],
+        ["modifyvm", "{{.Name}}", "--usb", "on", "--usbehci", "off", "--usbxhci", "off" ],
+        ["modifyvm", "{{.Name}}", "--vram", "64" ],
+        ["modifyvm", "{{.Name}}", "--vrde", "off" ],
+        ["storagectl", "{{.Name}}", "--name", "IDE Controller", "--remove" ],
+        ["storagectl", "{{.Name}}", "--name", "SATA Controller", "--hostiocache", "on" ]
+      ],
+
+      "vboxmanage_post": [
+        ["modifyvm", "{{.Name}}", "--accelerate3d", "on" ],
+        ["storageattach", "{{.Name}}", "--storagectl", "SATA Controller",
+          "--port", "1", "--type", "dvddrive", "--medium", "emptydrive"]
+      ],
+
+      "iso_url": "{{user `mirror_url`}}/{{user `iso_file`}}",
+      "iso_checksum_type": "sha256",
+      "iso_checksum_url": "{{user `mirror_url`}}/sha256sum.txt",
+      "iso_interface": "sata",
+
+      "hard_drive_discard": "true",
+      "hard_drive_interface": "sata",
+      "hard_drive_nonrotational": true,
+      "sata_port_count": 2,
+      "disk_size": "20480",
+
+      "guest_os_type": "Ubuntu_64",
+      "boot_wait": "5s",
+      "boot_command": [
+        "<esc><wait><esc><wait>",
+        "/casper/vmlinuz",
+
+        " auto url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/oem-preseed.cfg",
+        " automatic-ubiquity",
+        " debug-ubiquity",
+        " keymap=us",
+        " boot=casper initrd=/casper/initrd.lz quiet noprompt splash --",
+        "<enter>"
+      ],
+
+      "ssh_username": "{{user `ssh_user`}}",
+      "ssh_password": "{{user `ssh_pass`}}",
+      "ssh_timeout": "100m",
+      "shutdown_command": "echo -e \"{{user `ssh_pass`}}\\n\" | sudo -S poweroff",
+
+      "output_directory": "{{user `output_dir`}}",
+      "format": "ova",
+
+      "export_opts":
+      [
+        "--manifest",
+        "--vsys", "0",
+          "--description", "Build ID: {{user `build_id`}}",
+          "--product", "{{user `vm_name`}} {{user `semester`}}",
+          "--producturl", "https://linuxmint.com/",
+          "--vendor", "JMU Unix Users Group",
+          "--vendorurl", "{{user `git_repo`}}",
+          "--version", "{{user `version`}}"
+      ]
+    }
+  ],
+  "provisioners": [{
+    "type": "shell",
+    "execute_command": "echo 'oem' | sudo -S sh -c '{{ .Vars }} {{ .Path }}'",
+    "inline": [
+      "export DEBIAN_FRONTEND=noninteractive",
+      "apt-get update",
+      "apt-get install -y git ansible aptitude",
+      "git clone -b {{user `git_branch`}} {{user `git_repo`}}",
+      "cd /home/oem/cs-vm-build/scripts",
+      "./oem-build",
+      "/usr/sbin/oem-config-prepare"
+    ]
+  }],
+  "post-processors": [
+    {
+      "type": "checksum",
+      "output": "{{user `output_dir`}}/{{user `vm_name`}} {{user `semester`}}.{{.ChecksumType}}sum"
+    }
+  ]
+}

--- a/packer/ubuntu-build.json
+++ b/packer/ubuntu-build.json
@@ -1,8 +1,8 @@
 {
   "variables": {
-    "vm_name": "JMU Linux Mint",
-    "semester": "Sp20",
-    "mint_version": "19.3",
+    "vm_name": "JMU Ubuntu",
+    "semester": "Fa20",
+    "version": "20.04",
 
     "build_id": "{{isotime \"2006-01-02\"}}",
 
@@ -12,9 +12,9 @@
     "headless": "true",
     "audio": "pulse",
 
-    "output_dir": "{{pwd}}/artifacts",
-    "mirror_url": "http://mirror.cs.jmu.edu/pub/linuxmint/images/stable/19.3",
-    "iso_file": "linuxmint-19.3-cinnamon-64bit.iso",
+    "output_dir": "{{pwd}}/artifacts_ubuntu",
+    "mirror_url": "http://mirror.cs.jmu.edu/pub/ubuntu-iso/focal",
+    "iso_file": "ubuntu-20.04-desktop-amd64.iso",
 
     "ssh_user": "oem",
     "ssh_pass": "oem"
@@ -52,7 +52,7 @@
 
       "iso_url": "{{user `mirror_url`}}/{{user `iso_file`}}",
       "iso_checksum_type": "sha256",
-      "iso_checksum_url": "{{user `mirror_url`}}/sha256sum.txt",
+      "iso_checksum_url": "{{user `mirror_url`}}/SHA256SUMS",
       "iso_interface": "sata",
 
       "hard_drive_discard": "true",
@@ -64,14 +64,16 @@
       "guest_os_type": "Ubuntu_64",
       "boot_wait": "5s",
       "boot_command": [
-        "<esc><wait><esc><wait>",
+        "<esc><wait>",
+        "<esc><wait>",
+        "<esc><wait>",
+        "<enter><wait>",
         "/casper/vmlinuz",
-
         " auto url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/oem-preseed.cfg",
         " automatic-ubiquity",
         " debug-ubiquity",
         " keymap=us",
-        " boot=casper initrd=/casper/initrd.lz quiet noprompt splash --",
+        " boot=casper initrd=/casper/initrd noprompt --",
         "<enter>"
       ],
 
@@ -89,10 +91,10 @@
         "--vsys", "0",
           "--description", "Build ID: {{user `build_id`}}",
           "--product", "{{user `vm_name`}} {{user `semester`}}",
-          "--producturl", "https://linuxmint.com/",
+          "--producturl", "https://ubuntu.com/",
           "--vendor", "JMU Unix Users Group",
           "--vendorurl", "{{user `git_repo`}}",
-          "--version", "{{user `mint_version`}}"
+          "--version", "{{user `version`}}"
       ]
     }
   ],
@@ -101,8 +103,12 @@
     "execute_command": "echo 'oem' | sudo -S sh -c '{{ .Vars }} {{ .Path }}'",
     "inline": [
       "export DEBIAN_FRONTEND=noninteractive",
+      "echo UPDATE",
       "apt-get update",
-      "apt-get install -y git ansible aptitude",
+      "echo KILL",
+      "killall --quiet apt-get || true",
+      "echo INSTALL",
+      "apt-get install -V -y git ansible aptitude",
       "git clone -b {{user `git_branch`}} {{user `git_repo`}}",
       "cd /home/oem/cs-vm-build/scripts",
       "./oem-build",

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -4,16 +4,6 @@
 # All tasks in this file should be able to be run as part of the OEM or common
 # role without error as common is used in both of those.
 
-- name: Set OEM facts
-  set_fact:
-    wrapper_desktop_file_path: "/etc/skel/Desktop"
-    wrapper_desktop_file_mode: 0755
-  when: icon_mode == 'oem'
-- name: Set user facts
-  set_fact:
-    wrapper_desktop_file_path: "/usr/local/share/applications"
-    wrapper_desktop_file_mode: 0644
-  when: icon_mode == 'user'
 - name: Check Ubuntu release
   set_fact:
     ubuntu_release: "{{ lookup('ini', 'UBUNTU_CODENAME type=properties file=/etc/os-release') }}"
@@ -29,18 +19,6 @@
     path: "{{ log_directory }}"
     state: directory
     mode: 0755
-- name: Ensure desktop icon directory exists
-  file:
-    path: "{{ wrapper_desktop_file_path }}"
-    state: directory
-    mode: 0755
-# The policy file must go in /usr/share/polkit-1. It is the only location that
-# policykit checks
-- name: Install policykit policy for Ansible wrapper
-  copy:
-    src: edu.jmu.uug.ansiblewrapper.policy
-    dest: /usr/share/polkit-1/actions/
-    mode: 0644
 - name: Create directory for shared data
   file:
     path: "{{ share_directory }}"
@@ -48,6 +26,14 @@
     owner: root
     group: root
     mode: 0755
+
+# The policy file must go in /usr/share/polkit-1. It is the only location that
+# policykit checks
+- name: Install policykit policy for Ansible wrapper
+  copy:
+    src: edu.jmu.uug.ansiblewrapper.policy
+    dest: /usr/share/polkit-1/actions/
+    mode: 0644
 - name: Install Ansible wrapper GUI script
   template:
     src: uug_ansible_wrapper.py
@@ -59,44 +45,22 @@
     dest: "/usr/share/icons/hicolor/scalable/apps/{{ tux_icon_name }}.svg"
     mode: 0644
   notify: Update icon cache
+
+- name: Ensure local applications folder exists
+  file:
+    path: "{{ wrapper_desktop_file_path }}"
+    state: directory
+    mode: 0755
 - name: Copy shortcut to desktop file directory
   template:
     src: desktop-template.desktop.j2
     dest: "{{ wrapper_desktop_file_path }}/jmucs_config.desktop"
-    mode: "{{ wrapper_desktop_file_mode }}"
-- name: Create directory for custom MintReport script
-  file:
-    path: /usr/share/linuxmint/mintreport/reports/001_Run-JMU-CS-Config-Tool
     mode: 0755
-    owner: root
-    group: root
-    state: directory
-  when: ansible_distribution == "Linux Mint"
-- name: Install custom MintReport script
-  template:
-    src: CustomMintReportInfo.py
-    dest: /usr/share/linuxmint/mintreport/reports/001_Run-JMU-CS-Config-Tool/MintReportInfo.py
-    mode: 0644
-    owner: root
-    group: root
-  when: ansible_distribution == "Linux Mint"
 
-- name: Set Ubuntu mirrors
-  template:
-    src: ubuntu.j2
-    dest: /etc/apt/sources.list
-    owner: root
-    group: root
-    mode: 0664
-  when: ansible_distribution == "Ubuntu"
-- name: Set Linux Mint mirrors
-  template:
-    src: mint.j2
-    dest: /etc/apt/sources.list.d/official-package-repositories.list
-    owner: root
-    group: root
-    mode: 0644
-  when: ansible_distribution == "Linuxmint" or ansible_distribution == "Linux Mint"
+- include_tasks: ubuntu_only.yml
+  when: "ansible_distribution == 'Ubuntu'"
+- include_tasks: mint_only.yml
+  when: "ansible_distribution == 'Linux Mint'"
 - name: Refresh apt cache
   apt:
     update_cache: yes

--- a/roles/common/tasks/mint_only.yml
+++ b/roles/common/tasks/mint_only.yml
@@ -1,0 +1,25 @@
+---
+# tasks file for Linux Mint
+
+- name: Create directory for custom MintReport script
+  file:
+    path: /usr/share/linuxmint/mintreport/reports/001_Run-JMU-CS-Config-Tool
+    mode: 0755
+    owner: root
+    group: root
+    state: directory
+- name: Install custom MintReport script
+  template:
+    src: CustomMintReportInfo.py
+    dest: /usr/share/linuxmint/mintreport/reports/001_Run-JMU-CS-Config-Tool/MintReportInfo.py
+    mode: 0644
+    owner: root
+    group: root
+
+- name: Set Linux Mint mirrors
+  template:
+    src: mint.j2
+    dest: /etc/apt/sources.list.d/official-package-repositories.list
+    owner: root
+    group: root
+    mode: 0644

--- a/roles/common/tasks/ubuntu_only.yml
+++ b/roles/common/tasks/ubuntu_only.yml
@@ -1,0 +1,10 @@
+---
+# tasks file for Ubuntu
+
+- name: Set Ubuntu mirrors
+  template:
+    src: ubuntu.j2
+    dest: /etc/apt/sources.list
+    owner: root
+    group: root
+    mode: 0664

--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -18,3 +18,5 @@ share_directory: "/usr/local/share/jmu-uug"
 uug_ansible_wrapper: "{{ share_directory }}/uug_ansible_wrapper.py"
 
 tux_icon_name: "edu.jmu.uug.tux"
+
+wrapper_desktop_file_path: "/usr/local/share/applications"

--- a/roles/oem/files/csconfig-ubuntuonly
+++ b/roles/oem/files/csconfig-ubuntuonly
@@ -1,0 +1,13 @@
+[org/gnome/shell]
+favorite-apps=['ubiquity.desktop', 'firefox.desktop', 'org.gnome.Nautilus.desktop', 'libreoffice-writer.desktop', 'snap-store_ubuntu-software.desktop', 'yelp.desktop', 'jmucs_config.desktop']
+
+[org/gnome/desktop/screensaver]
+lock-delay=uint32 0
+lock-enabled=false
+
+[org/gnome/desktop/session]
+idle-delay=uint32 0
+ 
+[org/gnome/settings-daemon/plugins/power]
+sleep-inactive-ac-timeout=3600
+sleep-inactive-ac-type='nothing'

--- a/roles/oem/tasks/main.yml
+++ b/roles/oem/tasks/main.yml
@@ -1,42 +1,12 @@
 ---
 # tasks file for oem
 
-- name: Ensure this in Linux Mint
-  assert:
-    that:
-      - "ansible_distribution == 'Linuxmint' or ansible_distribution == 'Linux Mint'"
 - include_tasks: vm_only_pre.yml
   when: "ansible_virtualization_role == 'guest'"
 - name: Remove unused dependencies
   apt:
     autoremove: yes
-# Force an update of mintupdate, else it only updates itself on first run
-- name: Update mintupdate package
-  apt:
-    name: "{{ upgrade_pre_mintupdate }}"
-    state: latest
-- name: Upgrade all installed packages  # noqa 301
-  command: /usr/bin/mintupdate-cli -y upgrade
-- name: Install dependencies
-  apt:
-    name: "{{ packages_to_install }}"
-    state: latest
-- name: Copy welcome shortcut to skeleton desktop directory
-  copy:
-    src: welcome-to-vm.desktop
-    dest: /etc/skel/Desktop/welcome-to-vm.desktop
-    mode: 0644
-- name: Hide the mintwelcome window
-  file:
-    path: /etc/skel/.linuxmint/mintwelcome
-    mode: 0755
-    state: directory
-- name: Hide the mintwelcome window
-  copy:
-    dest: /etc/skel/.linuxmint/mintwelcome/norun.flag
-    mode: 0664
-    content: ""
-    force: no
+    purge: yes
 - name: Create the /usr/local/share/applications folder
   file:
     path: /usr/local/share/applications
@@ -63,6 +33,12 @@
     state: directory
     mode: 0755
     owner: root
+
+- include_tasks: ubuntu_only.yml
+  when: "ansible_distribution == 'Ubuntu'"
+- include_tasks: mint_only.yml
+  when: "ansible_distribution == 'Linux Mint'"
+
 # Some tasks should only be run when running as a guest OS.
 - include_tasks: vm_only_post.yml
   when: "ansible_virtualization_role == 'guest'"

--- a/roles/oem/tasks/mint_only.yml
+++ b/roles/oem/tasks/mint_only.yml
@@ -1,0 +1,36 @@
+---
+# tasks file for Linux Mint
+
+- name: Update mintupdate package
+  apt:
+    name: "{{ upgrade_pre_mintupdate }}"
+    state: latest
+- name: Upgrade all installed packages  # noqa 301
+  command: /usr/bin/mintupdate-cli -y upgrade
+
+- name: Ensure skeleton desktop directory exists
+  file:
+    path: "{{ skel_desktop_file_path }}"
+    state: directory
+    mode: 0755
+- name: Copy welcome shortcut to skeleton desktop directory
+  copy:
+    src: welcome-to-vm.desktop
+    dest: /etc/skel/Desktop/welcome-to-vm.desktop
+    mode: 0644
+- name: Hide the mintwelcome window
+  file:
+    path: /etc/skel/.linuxmint/mintwelcome
+    mode: 0755
+    state: directory
+- name: Hide the mintwelcome window
+  copy:
+    dest: /etc/skel/.linuxmint/mintwelcome/norun.flag
+    mode: 0664
+    content: ""
+    force: no
+- name: Copy setup script shortcut to desktop
+  copy:
+    src: "{{ wrapper_desktop_file_path }}/jmucs_config.desktop"
+    dest: "{{ skel_desktop_file_path }}/jmucs_config.desktop"
+    mode: 0755

--- a/roles/oem/tasks/ubuntu_only.yml
+++ b/roles/oem/tasks/ubuntu_only.yml
@@ -1,0 +1,15 @@
+---
+# tasks file for Ubuntu
+
+- name: Upgrade all installed packages
+  apt:
+    upgrade: safe
+- name: Copy dconf config file
+  copy:
+    src: csconfig-ubuntuonly
+    dest: /etc/dconf/db/local.d/csconfig-ubuntuonly
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - Update dconf database

--- a/roles/oem/vars/main.yml
+++ b/roles/oem/vars/main.yml
@@ -7,6 +7,8 @@ upgrade_pre_mintupdate:
   - mintupdate
   - mint-upgrade-info
 
+skel_desktop_file_path: "/etc/skel/Desktop"
+
 # https://github.com/jmunixusers/cs-vm-build/issues/11#issuecomment-347015788
 packages_to_remove:
   - bluez*
@@ -28,7 +30,7 @@ packages_to_remove:
   - fonts-nakula
   - fonts-nanum
   - fonts-navilu
-  - fonts-noto-cjk
+  - fonts-noto*
   - fonts-orya-extra
   - fonts-pagul
   - fonts-sahadeva
@@ -60,8 +62,8 @@ packages_to_remove:
   - hyphen-it
   - hyphen-pt*
   - hyphen-ru
-  - libllvm3.8
-  - libreoffice-common
+  - libreoffice*
+  - linux*oem
   - mint-artwork-mate
   - mint-backgrounds-sarah
   - mint-backgrounds-serena
@@ -89,5 +91,4 @@ packages_to_remove:
   - transmission*
   - vlc*
   - wbritish
-  - xplayer*
   - xscreensaver-*

--- a/roles/user/vars/main.yml
+++ b/roles/user/vars/main.yml
@@ -8,5 +8,5 @@ user_dependencies:
   - python3-psutil
   - unzip
   - vim
-  - vim-gnome
+  - vim-gtk3
   - zenity

--- a/scripts/oem-build
+++ b/scripts/oem-build
@@ -27,17 +27,6 @@ error () {
 }
 
 #---
-# Exits the script if the current distro is not Linux Mint.
-#---
-assert_mint() {
-    source /etc/os-release
-    local mint_name="Linux Mint"
-    if [ "$NAME" != "$mint_name" ]; then
-        error "The OEM role is only compatible with ${mint_name}. Not $NAME"
-    fi
-}
-
-#---
 # Installs VirtualBox Guest Additions if ISO file is present
 #---
 install_additions() {
@@ -66,17 +55,18 @@ main () {
         exit 1
     fi
 
-    assert_mint
-
-    user "Attempting to install VBox Guest Additions"
-    install_additions
+    user "Shutting down auto upgrades"
+    /usr/bin/systemctl stop unattended-upgrades.service
 
     user "Updating apt package cache"
     apt-get update
 
-    user "Installing ansible and git"
-    apt-get install --assume-yes ansible git aptitude\
-        || error "Unable to install ansible and git packages"
+    user "Installing prerequisite packages"
+    apt-get install -V --assume-yes ansible git aptitude gcc make perl \
+        || error "Unable to install prerequisite packages"
+
+    user "Attempting to install VBox Guest Additions"
+    install_additions
 
     user "Running ansible OEM playbook"
     # Ensure this runs from the root directory of the Ansible git directory


### PR DESCRIPTION
This branch is an attempt to add support for Ubuntu 20.04 LTS to our Packer and Ansible builds. Since this will be the first Ubuntu LTS upgrade within Mint since we started automating the builds, it had the potential to be a large effort to support. In the end, it was fairly minimal, but it forced some clarification between Mint and Ubuntu content.

It is not my intention for the UUG to start offering two images and a choice at InstallFests. This is solely being proposed so that we have a common target to develop for the next Mint release in a timely manner.

Every time I review these changes, I find more that I can't believe slipped my eye earlier, so I don't commit to them being done yet, but it's time to open them for public comment. I reserved the right to overwrite history and force push, especially while this remains in draft status.