### PR TITLE
Update jGRASP to 2.0.6_04

### DIFF
--- a/roles/jgrasp/vars/main.yml
+++ b/roles/jgrasp/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 # vars file for jgrasp
 jgrasp:
-  url: 'https://www.jgrasp.org/dl4g/jgrasp/jgrasp206_03.zip'
-  hash: '11cc4b8fd9dcc655cc03cb7107508b43cf292bd6'
+  url: 'https://www.jgrasp.org/dl4g/jgrasp/jgrasp206_04.zip'
+  hash: '5fb32382ecf695b2a267c50b415612f18b873b62'
   zip: '{{ global_base_path }}/jgrasp.zip'
   install_path: '{{ global_base_path }}/jgrasp'


### PR DESCRIPTION
Since the semester _just_ ended, it feels like it'd be good to keep jGRASP updated for a little longer.

Backports #386