### PR TITLE
Add linter to check hashes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -61,12 +61,12 @@ jobs:
           sudo apt-get -q install python3-gi-cairo gir1.2-gtk-3.0 libgirepository1.0-dev gir1.2-vte-2.91
       - name: Install dependencies
         run: |
-          pip3 install pyyaml pygobject pylint
+          pip3 install pyyaml pygobject pylint requests
       # We cannot just do roles/*/*/*py because we do not want to lint the
       # finch scripts which we cannot change
-      - name: Run common role pylint
+      - name: Run pylint
         run: |
-          pylint roles/common/*/*py
+          pylint roles/common/*/*.py scripts/*.py
   YAML:
     name: Run YAML lint tests
     runs-on: ubuntu-latest
@@ -89,3 +89,19 @@ jobs:
       - name: Run role-level yamllint
         run: |
           yamllint roles/*/*/*yml
+  Hashes:
+    name: Validate file hashes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - name: Install dependencies
+        run: |
+          pip3 install requests pyyaml
+      - name: Run hash validation
+        run: |
+          python3 scripts/hashlint.py

--- a/scripts/hashlint.py
+++ b/scripts/hashlint.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+"""
+Simple script to validate the various hashes for downloads across the project.
+"""
+
+import hashlib
+import sys
+
+import requests
+import yaml
+
+# https://requests.readthedocs.io/en/master/user/quickstart/#timeouts
+REQUEST_TIMEOUT_SEC = 5
+URLS = {
+    "roles/jgrasp/vars/main.yml": {
+        "hash": "jgrasp.hash",
+        "urls": ["jgrasp.url"],
+    },
+    "roles/finch/vars/main.yml": {
+        "hash": "finch.hash",
+        "urls": ["finch.url"],
+    },
+    "roles/eclipse/vars/main.yml": {
+        "hash": "eclipse.hash",
+        "urls": ["eclipse.url", "eclipse.url_backup"],
+    },
+}
+
+
+def get_field(data, key):
+    """
+    Get a field separated by dots
+    """
+
+    if isinstance(key, str):
+        key = key.split('.')
+    else:
+        print(type(key))
+    while key:
+        data = data[key.pop(0)]
+    return data
+
+
+def check_software_hash(session, url, expected, file):
+    """
+    Checks the hash for the contents of a URL against an expected value
+    """
+
+    try:
+        response = session.get(url, timeout=REQUEST_TIMEOUT_SEC)
+        response.raise_for_status()
+        data = response.content
+    # pylint: disable=broad-except
+    except Exception:
+        print(f"{file}: Unable to download {url}", file=sys.stderr)
+        return False
+
+    sha1 = hashlib.sha1(data).hexdigest()
+    if sha1 != expected:
+        print(f"{file}: Expected {expected}. Found {sha1}", file=sys.stderr)
+        return False
+
+    print(f"{file}: Validated {sha1=} as expected")
+
+    return True
+
+
+def main():
+    """
+    Main
+    """
+
+    session = requests.Session()
+    # User-Agent is the same as used by Ansible itself
+    # https://github.com/ansible/ansible/blob/062e780a68f9acd2ee6f824f252458b8a0351f24/lib/ansible/modules/get_url.py#L167
+    # This is particularly relevant for Finch, which will throw a 403 when
+    # downloading using the default User-Agent.
+    session.headers.update({'User-Agent': 'ansible-httpget'})
+    errors = 0
+    for file, hash_data in URLS.items():
+        with open(file) as software_data_file:
+            try:
+                software_data = yaml.safe_load(software_data_file)
+                expected_hash = get_field(software_data, hash_data['hash'])
+                for url_path in hash_data['urls']:
+                    url = get_field(software_data, url_path)
+                    if not check_software_hash(session, url, expected_hash, file):
+                        errors += 1
+            except KeyError:
+                print(f"{file}: File does not meet expected structure")
+                errors += 1
+
+    return errors
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
I have no idea how to properly test this. The goal is to have a linter that will be able to validate the hashes and URLs for the `vars` files. 

In my mind, this should just be a quicker way to validate that the new hashes and URLs that are given in a PR are valid without having to spin the VM up to validate them. We may accidentally get build failures if software updates and someone is modifying one of the listed files for an unrelated reason. I'd argue that if you're modifying one of the files that this PR watches, fixing hashes and URLs as necessary would generally be in-scope for that PR.