### PR TITLE
Update Packer lint to use new packaging format

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,9 +43,9 @@ jobs:
           unzip -d $HOME/packer $HOME/packer.zip
       - name: Packer validate
         run: |
-          $HOME/packer/pkg/packer_linux_amd64 validate packer/ubuntu-build.json
-          $HOME/packer/pkg/packer_linux_amd64 validate packer/mint-build.json
-          $HOME/packer/pkg/packer_linux_amd64 validate -var-file=packer/beta-vars.json packer/mint-build.json
+          $HOME/packer/packer validate packer/ubuntu-build.json
+          $HOME/packer/packer validate packer/mint-build.json
+          $HOME/packer/packer validate -var-file=packer/beta-vars.json packer/mint-build.json
   Python:
     name: Run Python lint tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
Packer seems to have updating their nightly packaging, breaking our lint test. I can't find any documentation that confirms the change was intentional/permanent, but I'm drafting this in case the change stays.