### PR TITLE
Install python wheel package

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -58,7 +58,7 @@ jobs:
           python-version: 3.x
       - name: Install Ubuntu dependencies
         run: |
-          sudo apt-get -q install python3-gi-cairo gir1.2-gtk-3.0 libgirepository1.0-dev gir1.2-vte-2.91
+          sudo apt-get -q install python3-wheel python3-gi-cairo gir1.2-gtk-3.0 libgirepository1.0-dev gir1.2-vte-2.91
       - name: Install dependencies
         run: |
           pip3 install pyyaml pygobject pylint requests


### PR DESCRIPTION
This should clean up some messages during the Python linting and allow
packages to be installed using the wheel format rather than the "legacy"
setup.py method.