### PR TITLE
Add cs432

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ using these tasks and the VM is available
 * Prolog
   * swi-prolog
 
+### CS432
+* (essentially same as CS261)
+
 ## Manual use of these Ansible roles
 
 This project was developed on and for Linux Mint, and receives occasional

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ using these tasks and the VM is available
     * g++
     * gcc
     * gdb
+    * graphviz
     * logisim
     * valgrind
-    * graphviz
   * Code editors
     * astyle
     * bvi
@@ -79,6 +79,7 @@ using these tasks and the VM is available
     * g++
     * gcc
     * gdb
+    * graphviz
     * logisim
     * valgrind
   * Code editors

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ using these tasks and the VM is available
     * gdb
     * logisim
     * valgrind
+    * graphviz
   * Code editors
     * astyle
     * bvi

--- a/local.yml
+++ b/local.yml
@@ -8,10 +8,10 @@
     - { role: wireless-printing, tags: always }
     - { role: filezilla, tags: always }
     - { role: basic-prog-pkgs, tags: ["cs101"] }
-    - { role: adv-prog-pkgs, tags: ["cs261", "cs361"] }
+    - { role: adv-prog-pkgs, tags: ["cs261", "cs361", "cs432"] }
     - { role: eclipse, tags: ["cs101", "cs149", "cs159"] }
     - { role: jgrasp, tags: ["cs149"] }
     - { role: finch, tags: ["cs101"] }
-    - { role: y86, tags: ["cs261"] }
+    - { role: y86, tags: ["cs261", "cs432"] }
     - { role: programming-langs, tags: ["cs430"] }
     - { role: vscode, tags: ["cs149"] }

--- a/roles/adv-prog-pkgs/tasks/main.yml
+++ b/roles/adv-prog-pkgs/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: Install source control packages
   apt:
-    name: '{{ adv_prog_pkgs_souce_control }}'
+    name: '{{ adv_prog_pkgs_source_control }}'
     state: latest
 
 - name: Install code editor packages

--- a/roles/adv-prog-pkgs/vars/main.yml
+++ b/roles/adv-prog-pkgs/vars/main.yml
@@ -7,6 +7,7 @@ adv_prog_pkgs_adv_lang:
   - gdb
   - logisim
   - valgrind
+  - graphviz
 
 adv_prog_pkgs_source_control:
   - git

--- a/roles/adv-prog-pkgs/vars/main.yml
+++ b/roles/adv-prog-pkgs/vars/main.yml
@@ -8,7 +8,7 @@ adv_prog_pkgs_adv_lang:
   - logisim
   - valgrind
 
-adv_prog_pkgs_souce_control:
+adv_prog_pkgs_source_control:
   - git
   - gitg
   - mercurial

--- a/roles/adv-prog-pkgs/vars/main.yml
+++ b/roles/adv-prog-pkgs/vars/main.yml
@@ -5,9 +5,9 @@ adv_prog_pkgs_adv_lang:
   - g++
   - gcc
   - gdb
+  - graphviz
   - logisim
   - valgrind
-  - graphviz
 
 adv_prog_pkgs_source_control:
   - git

--- a/roles/common/templates/uug_ansible_wrapper.py
+++ b/roles/common/templates/uug_ansible_wrapper.py
@@ -37,7 +37,8 @@ COURSES = {
     'CS 159': 'cs159',
     'CS 261': 'cs261',
     'CS 361': 'cs361',
-    'CS 430': 'cs430'
+    'CS 430': 'cs430',
+    'CS 432': 'cs432'
 }
 USER_CONFIG_PATH = os.path.join(os.environ['HOME'], ".config", "vm_config")
 USER_CONFIG = {


### PR DESCRIPTION
This adds (or attempts to add) CS432 support. I've ported the major class projects to C (previously they were in Java) and now the supported environment is nearly identical to CS261 (e.g., build/test with gcc/gdb/make/check, and need to work on stu or another Ubuntu-based machine because of compiled binaries and Valgrind).

The one difference that I can think of is that it's useful in CS432 to be able to build graphical ASTs using the "dot" utility. This is somewhat optional, but generally a useful thing and it's not too large so I've just added it (via the Graphviz package) to the "advanced programming" role for CS261/361/432.

I have not tested this myself so this is really just a suggested change and basis for discussion at this point. I'm not really set up to build it at the moment (getting an error about having too low of a Packer version) but I'm happy to test an image if someone else can build it.

Comments/questions welcome.