### PR TITLE
Update Eclipse to 2020-09

### DIFF
--- a/roles/eclipse/vars/main.yml
+++ b/roles/eclipse/vars/main.yml
@@ -3,9 +3,9 @@
 eclipse:
   # Ensure the URL does not specify a mirror and that &r=1 is at the end, which
   # directly links to the file and not the web page with a download button
-  url: 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/2020-06/R/eclipse-java-2020-06-R-linux-gtk-x86_64.tar.gz&r=1'
-  url_backup: 'http://mirror.cc.columbia.edu/pub/software/eclipse/technology/epp/downloads/release/2020-06/R/eclipse-java-2020-06-R-linux-gtk-x86_64.tar.gz'
-  hash: '0b8e4f48e4059da2aa758a60938c926f5ca27c28'
+  url: 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/2020-09/R/eclipse-java-2020-09-R-linux-gtk-x86_64.tar.gz&r=1'
+  url_backup: 'http://mirror.cc.columbia.edu/pub/software/eclipse/technology/epp/downloads/release/2020-09/R/eclipse-java-2020-09-R-linux-gtk-x86_64.tar.gz'
+  hash: 'bd7d65adead2c9313a65b0d3bf4e083dcda62ae0'
   zip: '{{ global_base_path }}/eclipse.tar.gz'
   install_path: '{{ global_base_path }}/eclipse'
 


### PR DESCRIPTION
Looks like this may not have made it to all the mirrors yet, but opening the PR so it's ready.

Resolves #412 