### PR TITLE
Revert "Stop trying to install transitional chromium package"

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ using these tasks and the VM is available
 * Mint packages (basic-prog-pkgs role)
   * artha
   * bless
+  * chromium-browser
   * geany
   * idle
   * libreoffice

--- a/roles/basic_prog_pkgs/vars/main.yml
+++ b/roles/basic_prog_pkgs/vars/main.yml
@@ -3,6 +3,7 @@
 basic_prog_pkgs_intro_development:
  - artha
  - bless
+ - chromium-browser
  - fonts-crosextra-caladea
  - fonts-crosextra-carlito
  - geany


### PR DESCRIPTION
Now that Ubuntu has a `chromium-browser` package that installs a snap, and Mint has a native package to provide the browser, we should be able to use this as it once was.

This reverts commit 8e0b9b0c88884d55d3e97babbd6cbb97e735f766.

Closes #394 