### PR TITLE
Add Shellcheck linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -67,6 +67,21 @@ jobs:
       - name: Run pylint
         run: |
           pylint roles/common/*/*.py scripts/*.py
+  Shell:
+    name: Run Shell linting
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Install shellcheck
+        run: |
+          sudo apt-get -q install shellcheck
+      # The profile is currently empty when placed on the machine; however, that
+      # may not always be the case. The file is shell code and should be linted
+      # as such.
+      - name: Run Shellcheck
+        run: |
+          shellcheck --shell=bash scripts/oem-build roles/user/files/csvmprofile
   YAML:
     name: Run YAML lint tests
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Ensure that we lint scripts/oem-build and some other known shell scripts
throughout the repository. Unfortunately, there is a nonzero amount of
shell code that gets generated using things like blockinfile that is
hard to actually lint this way. Two obvious files that we have that are
shell scripts are the oem-build script and the csvmprofile.

The csvmprofile is empty, as of this change. It gets content added to it
dynamically later but barring a full run & lint of files that we create,
at least making sure that what we track in the repo is valid is a good
start.
