### PR TITLE
Restore stu-home files

### DIFF
--- a/roles/user/files/stu-home.desktop
+++ b/roles/user/files/stu-home.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Version=1.0
+Name=Home on Stu
+Exec=sh -c "nemo sftp://\${USER}@stu.cs.jmu.edu/cs/home/stu/\${USER}/"
+Comment=Mount/umount your JMUCS NFS home directory
+Terminal=false
+Type=Application
+Categories=System;
+Icon=usermount
+Name[en_US]=Home on Stu

--- a/roles/user/files/stu-home.desktop
+++ b/roles/user/files/stu-home.desktop
@@ -6,5 +6,5 @@ Comment=Mount/umount your JMUCS NFS home directory
 Terminal=false
 Type=Application
 Categories=System;
-Icon=usermount
+Icon=gnome-fs-ssh
 Name[en_US]=Home on Stu

--- a/roles/user/tasks/main.yml
+++ b/roles/user/tasks/main.yml
@@ -56,6 +56,14 @@
     group: "{{ item.gid }}"
     state: directory
   loop: "{{ real_users }}"
+- name: Trust JMU CS student server SSH
+  known_hosts:
+    # Per ssh_config(5), this is the default value of GlobalKnownHostsFile
+    path: /etc/ssh/ssh_known_hosts
+    name: stu.cs.jmu.edu
+    key: "{{ stu_host_key }}"
+    hash_host: yes
+    state: present
 - name: Copy stu-home desktop
   copy:
     src: stu-home.desktop

--- a/roles/user/tasks/main.yml
+++ b/roles/user/tasks/main.yml
@@ -56,6 +56,14 @@
     group: "{{ item.gid }}"
     state: directory
   loop: "{{ real_users }}"
+- name: Copy stu-home desktop
+  copy:
+    src: stu-home.desktop
+    dest: '{{ item.homedir }}/Desktop'
+    owner: '{{ item.uid }}'
+    group: '{{ item.gid }}'
+    mode: 0750
+  with_items: "{{ real_users }}"
 # dest becomes path in Ansible 2.3+
 - name: Add profile to user bashrc
   lineinfile:

--- a/roles/user/vars/main.yml
+++ b/roles/user/vars/main.yml
@@ -10,3 +10,5 @@ user_dependencies:
   - vim
   - vim-gtk3
   - zenity
+
+stu_host_key: "stu.cs.jmu.edu ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILXS19kf1swKRC9GTTiUDyOzra0sYT+kt6Vxd4Q0H9uw"


### PR DESCRIPTION
In contrast to departmental guidance in 2018, it seems that it is now [supported](https://wiki.cs.jmu.edu/student/utilities/sshfs) (and recommended) to access stu via sshfs support.

Technically this isn't sshfs; it's Nemo's sftp support. But it's all basically the same and will largely present the same to students.

This partially reverts commit 190e9136e8cfc37eea2c5e3e88a303a12cb4d2f7.
This reverts commit 8bb25748cc87b5707fc15254f3984ddc6463877f.