### PR TITLE
Only configure Timeshift on Mint

### DIFF
--- a/roles/user/tasks/main.yml
+++ b/roles/user/tasks/main.yml
@@ -77,3 +77,4 @@
   become: yes
   become_user: "{{ item.user }}"
   loop: "{{ real_users }}"
+  when: "ansible_distribution == 'Linux Mint'"


### PR DESCRIPTION
Timeshift only exists on Mint and therefore should only be configured
there.

This has been split out from #418 (which is less likely to get merged).