### PR TITLE
Automatically update Ubuntu ISO

### DIFF
--- a/.github/workflows/auto-update-iso.yml
+++ b/.github/workflows/auto-update-iso.yml
@@ -1,0 +1,42 @@
+---
+name: Update ISOs
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+env:
+  UBUNTU_RELEASE: focal
+jobs:
+  update-ubuntu:
+    name: Update Ubuntu ISO file name
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -q -y jq
+      - name: Set latest ISO name
+        id: iso
+        run: |
+          MIRROR_URL="https://mirror.cs.jmu.edu/pub/ubuntu-iso/$UBUNTU_RELEASE"
+          ISO_NAME="$(curl -sL "$MIRROR_URL/SHA256SUMS" | grep desktop | head -n 1 | cut -d'*' -f 2)"
+          VERSION="$(echo "$ISO_NAME" | cut -d'-' -f 2)"
+          jq \
+            --arg iso "$ISO_NAME" \
+            --arg mirror "$MIRROR_URL" \
+            '.variables.iso_file = $iso | .variables.mirror_url = $mirror' packer/ubuntu-build.json > packer/ubuntu-build-update.json
+          mv packer/ubuntu-build-update.json packer/ubuntu-build.json
+          echo "::set-output name=version::$VERSION"
+          echo "::set-output name=iso_file::$ISO_NAME"
+          echo "::set-output name=mirror_url::$MIRROR_URL"
+      - name: Open a pull request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: >-
+            Update to Ubuntu ${{ steps.iso.outputs.version }}
+          title: Update to Ubuntu ${{ steps.iso.outputs.version }}
+          body: |
+            The latest desktop ISO referenced in ${{ steps.iso.outputs.mirror_url }}/SHA256SUMS
+            is `${{ steps.iso.outputs.iso_file }}`.
+          branch: ubuntu-update/${{ steps.iso.outputs.version }}
+          base: main


### PR DESCRIPTION
This adds the ability to automatically update the Ubuntu ISO within a release train which is
specified in the configuration. This will check every day at 9AM or when invoked manually. It will
push to an `ubuntu-update/` branch and open a pull request if there is a new ISO available.

Resolves: #436
Resolves: #409
