### PR TITLE
Update for Ansible Lint 5

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,4 +1,3 @@
 skip_list:
 # Package installs should not use latest
-  - 403
-
+  - package-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: 3.x
       - name: Install dependencies
         run: |
-          pip3 install ansible-lint
+          pip3 install ansible ansible-lint
       - name: Run ansible-lint
         run: |
           ansible-lint local.yml oem.yml

--- a/roles/oem/tasks/mint_only.yml
+++ b/roles/oem/tasks/mint_only.yml
@@ -5,7 +5,7 @@
   apt:
     name: "{{ upgrade_pre_mintupdate }}"
     state: latest
-- name: Upgrade all installed packages  # noqa 301
+- name: Upgrade all installed packages  # noqa no-changed-when
   command: /usr/bin/mintupdate-cli -y upgrade
 
 - name: Ensure skeleton desktop directory exists

--- a/roles/oem/tasks/ubuntu_only.yml
+++ b/roles/oem/tasks/ubuntu_only.yml
@@ -4,7 +4,7 @@
 - name: Upgrade all installed packages
   apt:
     upgrade: safe
-- name: Upgrade all installed snaps  # noqa 301
+- name: Upgrade all installed snaps  # noqa no-changed-when
   command: snap refresh
 - name: Copy dconf config file
   copy:

--- a/roles/oem/tasks/vm_only_post.yml
+++ b/roles/oem/tasks/vm_only_post.yml
@@ -43,7 +43,7 @@
 # The USB 2/3 controllers are only available with the Virtualbox
 # Extensions which are non-free software and available only under the Oracle
 # PUEL. We should ensure we have not accidentally included them.
-- name: Validate missing USB 2/3 controllers  # noqa 306
+- name: Validate missing USB 2/3 controllers  # noqa risky-shell-pipe
   command: lspci
   register: lspci_output
   failed_when: "'ECHI' in lspci_output.stdout or 'xHCI' in lspci_output.stdout"


### PR DESCRIPTION
Ansible Lint 5 doesn't seem to automatically depend on Ansible via pip, so adding that explicitly now. Also switches to named rules instead of numeric, causing an additional linting failure for us.