### PR TITLE
Add custom Ansible lint rule for mode arguments

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
           pip3 install ansible ansible-lint
       - name: Run ansible-lint
         run: |
-          ansible-lint local.yml oem.yml
+          ansible-lint -R -r lintrules/ansible local.yml oem.yml
   Packer:
     name: Run Packer lint tests
     runs-on: ubuntu-20.04

--- a/lintrules/ansible/ModeIsString.py
+++ b/lintrules/ansible/ModeIsString.py
@@ -1,0 +1,27 @@
+from typing import Any, Dict, Union
+
+import ansiblelint.utils
+from ansiblelint.rules import AnsibleLintRule
+
+class ModeIsString(AnsibleLintRule):
+    id = "mode-is-string"
+    shortdesc = "mode must be a string"
+    description = "File and directory modes must be strings"
+    tags = ['idiom']
+
+    def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
+        # Tasks without a mode should not be matched
+        if "action" not in task:
+            return False
+
+        invalid_mode_keys = []
+        # There are various mode-like keys, including "mode" and
+        # "directory_mode"
+        for key, value in task["action"].items():
+            if key.endswith("mode") and not isinstance(value, str):
+                invalid_mode_keys.append(key)
+
+        if not invalid_mode_keys:
+            return False
+
+        return f"The value for {invalid_mode_keys} should be a string"


### PR DESCRIPTION
Using non-string modes can be unpredictable in atypical cases. It is
usually safer to just use strings, whether representing the typical
numeric representation of permissions or the symbolic representation.

This is a lint check to enforce the opinions from #441.