### PR TITLE
Remove orange badge from mintupdate icon

### DIFF
--- a/roles/oem/files/csconfig-vmonly
+++ b/roles/oem/files/csconfig-vmonly
@@ -1,5 +1,6 @@
 [com/linuxmint/updates]
 warn-about-timeshift=false
+show-welcome-page=false
 
 [org/cinnamon/desktop/session]
 idle-delay=uint32 0

--- a/roles/user/tasks/main.yml
+++ b/roles/user/tasks/main.yml
@@ -100,3 +100,12 @@
   become_user: "{{ item.user }}"
   loop: "{{ real_users }}"
   when: "ansible_distribution == 'Linux Mint'"
+- name: Remove mintupdate welcome page
+  dconf:
+    key: "/com/linuxmint/updates/show-welcome-page"
+    value: "false"
+    state: present
+  become: yes
+  become_user: "{{ item.user }}"
+  loop: "{{ real_users }}"
+  when: "ansible_distribution == 'Linux Mint'"


### PR DESCRIPTION
On first boot (and until the user clicks "OK" on the welcome page), the
mintupdate-launcher icon has an orange badge on it. Since this tool
handles installing updates, it's showing an orange badge just to have
users press "OK" and see no updates.
