### PR TITLE
Update VS Code apt config

### DIFF
--- a/roles/vscode/tasks/main.yml
+++ b/roles/vscode/tasks/main.yml
@@ -4,11 +4,11 @@
   apt_key:
     id: BC528686B50D79E339D3721CEB3E94ADBE1229CF
     url: https://packages.microsoft.com/keys/microsoft.asc
-    keyring: /etc/apt/trusted.gpg.d/microsoft.gpg
+    keyring: /etc/apt/trusted.gpg.d/packages.microsoft.gpg
     state: present
 - name: Install VSCode Repository file
   apt_repository:
-    repo: deb [arch=amd64] https://packages.microsoft.com/repos/vscode stable main
+    repo: deb [arch=amd64,arm64,armhf signed-by=/etc/apt/trusted.gpg.d/packages.microsoft.gpg] https://packages.microsoft.com/repos/code stable main
     state: present
     filename: vscode
 - name: Install VSCode


### PR DESCRIPTION
Microsoft has changed the recommended apt sources entry for VS Code. In
addition to adding a signed-by entry, there is also a new URL without
`vs` in the name. https://code.visualstudio.com/docs/setup/linux