### PR TITLE
Basic ARM support

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -61,7 +61,7 @@ jobs:
           sudo apt-get -q install python3-gi-cairo gir1.2-gtk-3.0 libgirepository1.0-dev gir1.2-vte-2.91
       - name: Install dependencies
         run: |
-          pip3 install pyyaml pygobject pylint requests click PyGithub
+          pip3 install pyyaml pygobject pylint click PyGithub jinja2 aiohttp
       # We cannot just do roles/*/*/*py because we do not want to lint the
       # finch scripts which we cannot change
       - name: Run pylint
@@ -116,7 +116,7 @@ jobs:
           python-version: 3.x
       - name: Install dependencies
         run: |
-          pip3 install requests pyyaml
+          pip3 install aiohttp jinja2 pyyaml
       - name: Run hash validation
         run: |
           python3 scripts/hashlint.py

--- a/roles/common/tasks/mint_only.yml
+++ b/roles/common/tasks/mint_only.yml
@@ -23,3 +23,4 @@
     owner: root
     group: root
     mode: "0644"
+  when: "ansible_architecture == 'x86_64'"

--- a/roles/common/tasks/ubuntu_only.yml
+++ b/roles/common/tasks/ubuntu_only.yml
@@ -8,3 +8,4 @@
     owner: root
     group: root
     mode: "0664"
+  when: "ansible_architecture == 'x86_64'"

--- a/roles/eclipse/tasks/main.yml
+++ b/roles/eclipse/tasks/main.yml
@@ -13,7 +13,7 @@
       get_url:
         url: '{{ eclipse.url }}'
         dest: '{{ eclipse.zip }}'
-        checksum: 'sha1:{{ eclipse.hash }}'
+        checksum: 'sha1:{{ eclipse.hash[ansible_architecture] }}'
         timeout: 30
         force: yes
       register: url_output
@@ -22,7 +22,7 @@
       get_url:
         url: '{{ eclipse.url_backup }}'
         dest: '{{ eclipse.zip }}'
-        checksum: 'sha1:{{ eclipse.hash }}'
+        checksum: 'sha1:{{ eclipse.hash[ansible_architecture] }}'
         timeout: 30
         force: yes
       when: url_output.failed
@@ -37,7 +37,7 @@
         owner: root
         group: root
         mode: "0755"
-  when: st.stat.checksum|default("") != eclipse.hash
+  when: st.stat.checksum|default("") != eclipse.hash[ansible_architecture]
 - name: Install checkstyle plugin
   command: >
     {{ eclipse.install_path }}/eclipse

--- a/roles/eclipse/vars/main.yml
+++ b/roles/eclipse/vars/main.yml
@@ -3,9 +3,11 @@
 eclipse:
   # Ensure the URL does not specify a mirror and that &r=1 is at the end, which
   # directly links to the file and not the web page with a download button
-  url: 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/2021-03/R/eclipse-java-2021-03-R-linux-gtk-x86_64.tar.gz&r=1'
-  url_backup: 'http://mirror.cc.columbia.edu/pub/software/eclipse/technology/epp/downloads/release/2021-03/R/eclipse-java-2021-03-R-linux-gtk-x86_64.tar.gz'
-  hash: 'c9667a04465af84eb66c6bf28a3dee93d4d79d0e'
+  url: 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/2021-03/R/eclipse-java-2021-03-R-linux-gtk-{{ ansible_architecture }}.tar.gz&r=1'
+  url_backup: 'http://mirror.cc.columbia.edu/pub/software/eclipse/technology/epp/downloads/release/2021-03/R/eclipse-java-2021-03-R-linux-gtk-{{ ansible_architecture }}.tar.gz'
+  hash:
+    x86_64: 'c9667a04465af84eb66c6bf28a3dee93d4d79d0e'
+    aarch64: '516b32c8dc083ab58d1d2ddb631c6e2d5b6e48e9'
   zip: '{{ global_base_path }}/eclipse.tar.gz'
   install_path: '{{ global_base_path }}/eclipse'
 

--- a/roles/eclipse/vars/main.yml
+++ b/roles/eclipse/vars/main.yml
@@ -4,7 +4,7 @@ eclipse:
   # Ensure the URL does not specify a mirror and that &r=1 is at the end, which
   # directly links to the file and not the web page with a download button
   url: 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/2021-03/R/eclipse-java-2021-03-R-linux-gtk-{{ ansible_architecture }}.tar.gz&r=1'
-  url_backup: 'http://mirror.cc.columbia.edu/pub/software/eclipse/technology/epp/downloads/release/2021-03/R/eclipse-java-2021-03-R-linux-gtk-{{ ansible_architecture }}.tar.gz'
+  url_backup: 'https://download.eclipse.org/technology/epp/downloads/release/2021-03/R/eclipse-java-2021-03-R-linux-gtk-{{ ansible_architecture }}.tar.gz'
   hash:
     x86_64: 'c9667a04465af84eb66c6bf28a3dee93d4d79d0e'
     aarch64: '516b32c8dc083ab58d1d2ddb631c6e2d5b6e48e9'

--- a/scripts/hashlint.py
+++ b/scripts/hashlint.py
@@ -4,14 +4,17 @@
 Simple script to validate the various hashes for downloads across the project.
 """
 
+import asyncio
 import hashlib
 import sys
 
-import requests
+from collections import namedtuple
+from typing import Any, Dict
+
+import aiohttp
+import jinja2
 import yaml
 
-# https://requests.readthedocs.io/en/master/user/quickstart/#timeouts
-REQUEST_TIMEOUT_SEC = 5
 URLS = {
     "roles/jgrasp/vars/main.yml": {
         "hash": "jgrasp.hash",
@@ -28,71 +31,126 @@ URLS = {
 }
 
 
-def get_field(data, key):
+CheckData = namedtuple("CheckData", ["url", "expected_hash", "source_file"])
+
+
+def get_field(data: Dict[str, Dict[str, Any]], key: str) -> Any:
     """
-    Get a field separated by dots
+    Get a field from nested dictionary, with the field denoted with dot-separated keys.
+
+    For example, "a.b.c" -> data['a']['b']['c']
     """
 
-    if isinstance(key, str):
-        key = key.split('.')
-    else:
-        print(type(key))
-    while key:
-        data = data[key.pop(0)]
+    keys = key.split(".")
+
+    while keys:
+        data = data[keys.pop(0)]
+
     return data
 
 
-def check_software_hash(session, url, expected, file):
+async def check_software_hash(
+    session: aiohttp.ClientSession, check_data: CheckData
+) -> bool:
     """
-    Checks the hash for the contents of a URL against an expected value
+    Checks the hash for the contents of a URL against an expected value.
     """
 
     try:
-        response = session.get(url, timeout=REQUEST_TIMEOUT_SEC)
-        response.raise_for_status()
-        data = response.content
-    # pylint: disable=broad-except
-    except Exception:
-        print(f"{file}: Unable to download {url}", file=sys.stderr)
+        async with session.get(check_data.url) as response:
+            data = await response.read()
+    except aiohttp.ClientError:
+        print(
+            f"{check_data.source_file}: Unable to download {check_data.url}",
+            file=sys.stderr,
+        )
         return False
 
     sha1 = hashlib.sha1(data).hexdigest()
-    if sha1 != expected:
-        print(f"{file}: Expected {expected}. Found {sha1}", file=sys.stderr)
+    if sha1 != check_data.expected_hash:
+        print(
+            f"{check_data.source_file}: Expected {check_data.expected_hash}. Found {sha1}",
+            file=sys.stderr,
+        )
         return False
 
-    print(f"{file}: Validated {sha1=} as expected")
+    print(
+        f"{check_data.source_file}: Validated {sha1=} as expected from {check_data.url}"
+    )
 
     return True
 
 
-def main():
+def process_variable(source: str, variable: str, value: str) -> str:
+    """
+    Process the string and substitute the variable and value.
+    """
+
+    template = jinja2.Template(source)
+    return template.render(**{variable: value})
+
+
+def urls_for_file(file: str, ansible_data: Dict[str, Any], lookup_data: Dict[str, Any]):
+    """
+    Return a set of all URLs in the given file key in the URLs mapping.
+    """
+
+    hash_data = get_field(ansible_data, lookup_data["hash"])
+    if not isinstance(hash_data, dict):
+        # We never actually care about the architecture name, so forcing this
+        # to be a dictionary is a useful way to make the code cleaner later
+        hash_data = {"_": hash_data}
+
+    # Pull the unprocessed URLs from the Ansible variables; the assumption is that the
+    # only jinja2-looking part of the URL, if there is one, is the `ansible_architecture`
+    # which should be fine since `{{ }}` probably won't be in a URL and jinja2 is perfectly
+    # content to be given templates that don't contain a given variable
+    raw_urls = [get_field(ansible_data, url_path) for url_path in lookup_data["urls"]]
+
+    checks = set()
+    for url in raw_urls:
+        for arch, expected_hash in hash_data.items():
+            new_url = process_variable(url, "ansible_architecture", arch)
+            checks.add(CheckData(new_url, expected_hash, file))
+    return checks
+
+
+async def main():
     """
     Main
     """
 
-    session = requests.Session()
     # User-Agent is the same as used by Ansible itself
     # https://github.com/ansible/ansible/blob/062e780a68f9acd2ee6f824f252458b8a0351f24/lib/ansible/modules/get_url.py#L167
     # This is particularly relevant for Finch, which will throw a 403 when
     # downloading using the default User-Agent.
-    session.headers.update({'User-Agent': 'ansible-httpget'})
+    headers = {"User-Agent": "ansible-httpget"}
     errors = 0
+    to_check = set()
     for file, hash_data in URLS.items():
         with open(file) as software_data_file:
+            software_data = yaml.safe_load(software_data_file)
             try:
-                software_data = yaml.safe_load(software_data_file)
-                expected_hash = get_field(software_data, hash_data['hash'])
-                for url_path in hash_data['urls']:
-                    url = get_field(software_data, url_path)
-                    if not check_software_hash(session, url, expected_hash, file):
-                        errors += 1
+                to_check |= urls_for_file(file, software_data, hash_data)
             except KeyError:
                 print(f"{file}: File does not meet expected structure")
                 errors += 1
 
+    async with aiohttp.ClientSession(headers=headers, raise_for_status=True) as session:
+        tasks = [
+            asyncio.create_task(check_software_hash(session, check_data))
+            for check_data in to_check
+        ]
+        # The gather must occur within the `with` otherwise the session may be closed
+        # when the threads attempt to use it to download the file
+        for result in await asyncio.gather(*tasks):
+            # This relies on the fact that True gets coerced to 1 and that False gets
+            # coerced to 0 when converted to an integer. The check method returns True
+            # on success and we need to count failures.
+            errors += not result
+
     return errors
 
 
-if __name__ == '__main__':
-    sys.exit(main())
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))


### PR DESCRIPTION
This gets the configuration scripts working well enough on Ubuntu
aarch64 that there aren't failures for any role and that it doesn't
break any core parts of the OS.

It's not perfect since the y86 tools and others aren't ready for
aarch64. I don't really intend to propose that we go all-out on
making aarch64 work perfectly; just that we don't break too much that
already works if someone does try to run it.
