### PR TITLE
Misc fixes may21

### DIFF
--- a/.github/workflows/auto-update-iso.yml
+++ b/.github/workflows/auto-update-iso.yml
@@ -8,6 +8,7 @@ env:
   UBUNTU_RELEASE: focal
 jobs:
   update-ubuntu:
+    if: github.repository == 'jmunixusers/cs-vm-build'
     name: Update Ubuntu ISO file name
     runs-on: ubuntu-latest
     steps:

--- a/roles/eclipse/tasks/main.yml
+++ b/roles/eclipse/tasks/main.yml
@@ -43,7 +43,7 @@
     {{ eclipse.install_path }}/eclipse
     -nosplash
     -application org.eclipse.equinox.p2.director
-    -repository http://eclipse-cs.sourceforge.net/update/
+    -repository https://checkstyle.org/eclipse-cs-update-site/
     -installIU net.sf.eclipsecs.feature.group
     -destination {{ eclipse.install_path }}
   args:

--- a/roles/user/tasks/main.yml
+++ b/roles/user/tasks/main.yml
@@ -79,6 +79,7 @@
     group: '{{ item.gid }}'
     mode: "0750"
   with_items: "{{ real_users }}"
+  when: "ansible_distribution == 'Linux Mint'"
 - name: Add profile to user bashrc
   lineinfile:
     path: '{{ item.homedir }}/.bashrc'

--- a/scripts/oem-build
+++ b/scripts/oem-build
@@ -86,7 +86,7 @@ main () {
     apt-get update
 
     user "Installing prerequisite packages"
-    apt-get install -V ansible git aptitude gcc make perl \
+    apt-get install -V -y ansible git aptitude gcc make perl \
         || error "Unable to install prerequisite packages"
 
     user "Attempting to install VBox Guest Additions"


### PR DESCRIPTION
Just a few cleanups discovered in playing with the codebase lately.

1. Eclipse Checkstyle has moved the repository, so update that URL
2. The stu-home shortcut uses Cinnamon Nemo and doesn't work with Ubuntu, so make that a mint-only task. Ubuntu shortcuts also seem to require world-exec and `gio set file.desktop "metadata::trusted" yes` to run
3. Ubuntu 21.04 packer aborts without the apt "-y" flag, which we use elsewhere and most examples seem to show. I'm not sure how this was working before, but I think noninteractive mode is meant to suppress package prompts
4. The Ubuntu ISO checker is running on forks, which would likely cause diverging commits on the main branch