### PR TITLE
Cache `ETag` and `Last-Modified` headers

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -117,6 +117,13 @@ jobs:
       - name: Install dependencies
         run: |
           pip3 install aiohttp jinja2 pyyaml
+      - name: Configure download cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/hashlint
+          key: hashlint-cache-${{ github.sha }}
+          restore-keys:
+            hashlint-cache-
       - name: Run hash validation
         run: |
           python3 scripts/hashlint.py

--- a/scripts/hashlint.py
+++ b/scripts/hashlint.py
@@ -6,15 +6,22 @@ Simple script to validate the various hashes for downloads across the project.
 
 import asyncio
 import hashlib
+import json
 import sys
 
 from collections import namedtuple
-from typing import Any, Dict
+from pathlib import Path
+
+# Importing these types using in the string type hints is helpful for some
+# editors to actually support hinting for these types.
+# pylint: disable=unused-import
+from typing import Any, Dict, List, Set, Tuple, Type
 
 import aiohttp
 import jinja2
 import yaml
 
+CACHE_FILE = Path.home() / ".cache" / "hashlint" / "cache.json"
 URLS = {
     "roles/jgrasp/vars/main.yml": {
         "hash": "jgrasp.hash",
@@ -34,6 +41,110 @@ URLS = {
 CheckData = namedtuple("CheckData", ["url", "expected_hash", "source_file"])
 
 
+class CacheItem:
+    """
+    An item stored in the URL/ETag cache.
+    """
+
+    def __init__(self, url, etag, last_modified, file_hash):
+        self.url = url
+        self.etag = etag
+        self.last_modified = last_modified
+        self.hash = file_hash
+
+    def __repr__(self):
+        url = self.url
+        etag = self.etag
+        last_modified = self.last_modified
+        return f"<Cache {url=!r} {etag=!r} {last_modified=!r} hash={self.hash!r}>"
+
+    def to_json(self) -> Dict[str, Dict[str, str]]:
+        """
+        Return the cache item as a JSON serializable dictionary.
+        """
+        return {
+            str(self.url): {
+                "ETag": self.etag,
+                "Last-Modified": self.last_modified,
+                "hash": self.hash,
+            }
+        }
+
+    @classmethod
+    def from_json(cls, data) -> "List[Type[CacheItem]]":
+        """
+        Load an item from the cache.
+        """
+        return [
+            cls(
+                key, cache_data["ETag"], cache_data["Last-Modified"], cache_data["hash"]
+            )
+            for key, cache_data in data.items()
+        ]
+
+    @classmethod
+    async def from_http_response(
+        cls, response: aiohttp.ClientResponse
+    ) -> "Type[CacheItem]":
+        """
+        Parse a cache item from an HTTP response
+        """
+        headers = response.headers
+        url = response.url
+        data = await response.read()
+        file_hash = hashlib.sha1(data).hexdigest()
+
+        return cls(url, headers.get("ETag"), headers.get("Last-Modified"), file_hash)
+
+
+class Cache:
+    """
+    A cache of all downloaded items.
+    """
+
+    def __init__(self):
+        self._items = []
+
+    def __getitem__(self, url):
+        return next(item for item in self._items if item.url == url)
+
+    def __setitem__(self, url, item):
+        if matches := [cached for cached in self._items if cached.url == url]:
+            match = matches[0]
+            self._items.remove(match)
+        self._items.append(item)
+
+    def __bool__(self):
+        return bool(self._items)
+
+    def __contains__(self, url):
+        return bool([item for item in self._items if item.url == url])
+
+    def __iter__(self):
+        return iter([item.url for item in self._items])
+
+    def __repr__(self):
+        return f"<Cache items={self._items!r}>"
+
+    @classmethod
+    def from_json(cls, data: Dict[str, Dict[str, str]]) -> 'Type[Cache]':
+        """
+        Load a cache from a dictionary.
+        """
+        cache = cls()
+        cache._items = list(CacheItem.from_json(data))
+        return cache
+
+    def to_json(self) -> Dict[str, Dict[str, str]]:
+        """
+        Return the cache as a JSON serializable dictionary.
+        """
+        cache = {}
+        for item in self._items:
+            cache.update(item.to_json())
+        return cache
+
+
 def get_field(data: Dict[str, Dict[str, Any]], key: str) -> Any:
     """
     Get a field from nested dictionary, with the field denoted with dot-separated keys.
@@ -50,15 +161,27 @@ def get_field(data: Dict[str, Dict[str, Any]], key: str) -> Any:
 
 
 async def check_software_hash(
-    session: aiohttp.ClientSession, check_data: CheckData
+    session: aiohttp.ClientSession, check_data: CheckData, cache: Cache
 ) -> bool:
     """
     Checks the hash for the contents of a URL against an expected value.
     """
 
+    headers = {}
+    if check_data.url in cache:
+        cache_item = cache[check_data.url]
+        if cache_item.etag:
+            headers["If-None-Exists"] = cache_item.etag
+        if cache_item.last_modified:
+            headers["If-Modified-Since"] = cache_item.last_modified
+
     try:
-        async with session.get(check_data.url) as response:
-            data = await response.read()
+        async with session.get(
+            check_data.url, headers=headers, timeout=600
+        ) as response:
+            if response.status == 200:
+                cache_item = await CacheItem.from_http_response(response)
+                cache[check_data.url] = cache_item
     except aiohttp.ClientError:
         print(
             f"{check_data.source_file}: Unable to download {check_data.url}",
@@ -66,7 +189,7 @@ async def check_software_hash(
         )
         return False
 
-    sha1 = hashlib.sha1(data).hexdigest()
+    sha1 = cache_item.hash
     if sha1 != check_data.expected_hash:
         print(
             f"{check_data.source_file}: Expected {check_data.expected_hash}. Found {sha1}",
@@ -115,30 +238,61 @@ def urls_for_file(file: str, ansible_data: Dict[str, Any], lookup_data: Dict[str
     return checks
 
 
+def load_cache() -> Cache:
+    """
+    Load the cache from disk.
+    """
+    if CACHE_FILE.exists():
+        with open(CACHE_FILE, encoding="utf-8") as cache:
+            return Cache.from_json(json.load(cache))
+    return Cache()
+
+
+def write_cache(cache: Cache):
+    """
+    Save the cache to disk.
+    """
+    CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with open(CACHE_FILE, "w", encoding="utf-8") as cache_file:
+        json.dump(cache.to_json(), cache_file, indent=4)
+
+
+def get_urls() -> Tuple[Set[str], int]:
+    """
+    Load the list of URLs to validate hashes for as well as the number of errors
+    encountered parsing the list.
+    """
+    errors = 0
+    to_check = set()
+    for file, hash_data in URLS.items():
+        with open(file) as software_data_file:
+            software_data = yaml.safe_load(software_data_file)
+        try:
+            to_check |= urls_for_file(file, software_data, hash_data)
+        except KeyError:
+            print(f"{file}: File does not meet expected structure")
+            errors += 1
+    return to_check, errors
+
+
 async def main():
     """
     Main
     """
+
+    cache = load_cache()
+    print(f"Cache loaded: {cache}")
+
+    to_check, errors = get_urls()
 
     # User-Agent is the same as used by Ansible itself
     # https://github.com/ansible/ansible/blob/062e780a68f9acd2ee6f824f252458b8a0351f24/lib/ansible/modules/get_url.py#L167
     # This is particularly relevant for Finch, which will throw a 403 when
     # downloading using the default User-Agent.
     headers = {"User-Agent": "ansible-httpget"}
-    errors = 0
-    to_check = set()
-    for file, hash_data in URLS.items():
-        with open(file) as software_data_file:
-            software_data = yaml.safe_load(software_data_file)
-            try:
-                to_check |= urls_for_file(file, software_data, hash_data)
-            except KeyError:
-                print(f"{file}: File does not meet expected structure")
-                errors += 1
-
     async with aiohttp.ClientSession(headers=headers, raise_for_status=True) as session:
         tasks = [
-            asyncio.create_task(check_software_hash(session, check_data))
+            asyncio.create_task(check_software_hash(session, check_data, cache))
             for check_data in to_check
         ]
         # The gather must occur within the `with` otherwise the session may be closed
@@ -149,6 +303,8 @@ async def main():
             # on success and we need to count failures.
             errors += not result
 
+    write_cache(cache)
+    print(f"Wrote cache: {cache}")
     return errors
 
 


### PR DESCRIPTION
Caching these headers gives two pretty significant benefits: the first is that we improve performance a bit by caching these fields and the file hash, the second is that we reduce the need for the upstream servers to send the full files in the response to the `GET` request. The cache is preserved using the `actions/cache@v2` Action. This will work fine since the goal of this check is to find files that have either had their hash change or that have disappeared.

## Cache Preservation

The cache is preserved between executions using `actions/cache@v2`. The cache is preserved for up to 7 days, so we'll be able to rely on it so long as we run the lint at least about that often. We also need to specify a unique cache key for each execution because when the Action has an exact cache hit, it doesn't write the cache back. Using a unique key each time but with a common restore key prefix allows us to restore the most recent cache and also write it back each time. If we do lose the cache, it's not a big deal. We just run with an empty cache and write it back again at the end.

## Cache Contents

The cache stores the following attributes for each URL:
- the `ETag` header returned in the response
- the `Last-Modified` header returned in the response
- the SHA1 hash of the response body

We preserve both the `ETag` and the `Last-Modified` headers because some servers (like Finch's) don't respond with an `ETag`. This lets us have a fallback to try to use the hash. And the hash itself is preserved because with a 304 response, we don't get a body. So we need to either cache the full body (which takes way more storage) or just the hash (which is far easier). We always preserve the hash of the response; we don't try to preserve the expected hash. This means that if you receive an invalid hash, it should fail time after time (so long as the ETag doesn't change) because you've stored the hash.

## Command Output

This adds an additional line at the beginning and the end of the script execution that gives information on the data that was read from and written to the cache. This data should be fairly static between executions unless there's a cache miss. It should be helpful to always have the output for debugging in case we run into a cache issue.

## Cache Location

The cache is stored at `~/.cache/hashlint/cache.json`. This keeps it in a directory that still should be accessible or should be able to be created when executing the script locally. For simplicity, we don't try to pull in XDG Dirs configuration.