### PR TITLE
Hold Mesa packages to prevent white-out bug

### DIFF
--- a/roles/oem/tasks/vm_only_pre.yml
+++ b/roles/oem/tasks/vm_only_pre.yml
@@ -11,3 +11,8 @@
     path: /var/lib/dpkg/arch
     state: absent
     line: 'i386'
+- name: Hold Mesa packages
+  dpkg_selections:
+    name: '{{ item }}'
+    selection: hold
+  loop: "{{ mesa_hold_packages }}"

--- a/roles/oem/vars/main.yml
+++ b/roles/oem/vars/main.yml
@@ -7,6 +7,18 @@ upgrade_pre_mintupdate:
 skel_path: "/etc/skel"
 skel_desktop_file_path: "{{ skel_path }}/Desktop"
 
+mesa_hold_packages:
+  - libegl-mesa0
+  - libgbm1
+  - libgl1-mesa-dri
+  - libgl1-mesa-glx
+  - libglapi-mesa
+  - libglx-mesa0
+  - libxatracker2
+  - mesa-va-drivers
+  - mesa-vdpau-drivers
+  - mesa-vulkan-drivers
+
 # https://github.com/jmunixusers/cs-vm-build/issues/11#issuecomment-347015788
 packages_to_remove:
   - bluez*


### PR DESCRIPTION
We've missed a serious bug so far, and I kind of hate this patch, but we need to get something published soon. Ubuntu recently updated the mesa drivers and they don't work when VirtualBox 3d acceleration is enabled. 

- https://forums.linuxmint.com/viewtopic.php?t=354405
- https://gitlab.freedesktop.org/mesa/mesa/-/issues/5192
- https://github.com/linuxmint/linuxmint/issues/409

Pinning the packages allows us to ship a working image for now, and we can backport an "un-hold" when the problem is resolved.