### PR TITLE
Fix Python buffering in wrapper

### DIFF
--- a/roles/common/templates/uug_ansible_wrapper.py
+++ b/roles/common/templates/uug_ansible_wrapper.py
@@ -418,9 +418,11 @@ class AnsibleWrapperWindow(Gtk.Window):
         )
 
         with TemporaryDirectory() as temp_dir:
-            # spawn_sync will not perform a path lookup; however, pkexec will
+            # spawn_sync will not perform a path lookup; however, pkexec and env will
             cmd_args = [
                 '/usr/bin/pkexec',
+                "env",
+                "PYTHONUNBUFFERED=1",
                 'ansible-pull',
                 '--url',
                 USER_CONFIG['git_url'],


### PR DESCRIPTION
pkexec has a pretty strict policy around setting environment variables
and will ignore most all of them except for a known, safe subset and a
few vars that may be required for GUI applications (for policies that
opt-in to that). Applications, of course, can still control their own
environment variables. So we can likely have `env` set some variables
then have it exec `ansible-pull`.

Resolves: #404
