### PR TITLE
Spring 2022 Updates for wrapper script

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -68,7 +68,7 @@ jobs:
           sudo apt-get -q install python3-gi-cairo gir1.2-gtk-3.0 libgirepository1.0-dev gir1.2-vte-2.91
       - name: Install dependencies
         run: |
-          pip3 install pyyaml pygobject pylint click PyGithub jinja2 aiohttp
+          pip3 install pyyaml pygobject pylint click PyGithub jinja2 aiohttp pyxdg
       - name: Run pylint
         run: |
           pylint roles/*/*/*.py scripts/*.py

--- a/roles/common/templates/uug_ansible_wrapper.py
+++ b/roles/common/templates/uug_ansible_wrapper.py
@@ -17,6 +17,7 @@ import pathlib
 import re
 import subprocess
 import urllib.request
+import webbrowser
 from tempfile import TemporaryDirectory
 
 import yaml
@@ -264,9 +265,17 @@ class AnsibleWrapperWindow(Gtk.Window):
         about.connect("activate", self.show_about_dialog)
         help_menu.append(about)
 
+        # Add a documentation link to the help menu
+        docs = Gtk.MenuItem(label="Documentation")
+        docs.connect("activate", self.open_docs)
+        help_menu.append(docs)
+
         menu_bar.append(help_item)
 
         self.vbox.pack_start(menu_bar, False, False, 0)
+
+    def open_docs(self, _):
+        webbrowser.open("http://www.jmunixusers.org/presentations/vm/")
 
     def show_settings(self, _):
         """
@@ -295,7 +304,7 @@ class AnsibleWrapperWindow(Gtk.Window):
             "maintained by the Unix Users Group"
         )
         about_dialog.set_authors(["JMU Unix Users Group"])
-        about_dialog.set_website("https://github.com/jmunixusers/cs-vm-build")
+        about_dialog.set_website("http://github.com/jmunixusers/cs-vm-build")
         about_dialog.set_website_label("Project GitHub page")
         about_dialog.set_version(VERSION)
         about_dialog.set_license_type(Gtk.License.MIT_X11)

--- a/roles/common/templates/uug_ansible_wrapper.py
+++ b/roles/common/templates/uug_ansible_wrapper.py
@@ -497,6 +497,7 @@ class SettingsDialog(Gtk.Dialog):
 
         branch_label = self._create_label("Release track:")
         url_label = self._create_label("Source URL:")
+        ignore_main_label = self._create_label("Development:")
         experimental_label = self._create_label("Experimental:")
 
         branch_entry = self._create_entry(USER_CONFIG["git_branch"])
@@ -505,17 +506,20 @@ class SettingsDialog(Gtk.Dialog):
             "Allow running unsupported/experimental courses",
             USER_CONFIG["allow_experimental"],
         )
+        ignore_main_check = self._create_checkbox(
+            "Allow running from development branch",
+            USER_CONFIG.get("ignore_main", False)
+        )
 
         self._register_setting("git_branch", branch_entry)
         self._register_setting("git_url", url_entry)
         self._register_setting("allow_experimental", experimental_check)
+        self._register_setting("ignore_main", ignore_main_check)
 
-        grid.attach(branch_label, 0, 0, 1, 1)
-        grid.attach(branch_entry, 1, 0, 1, 1)
-        grid.attach(url_label, 0, 1, 1, 1)
-        grid.attach(url_entry, 1, 1, 1, 1)
-        grid.attach(experimental_label, 0, 2, 1, 1)
-        grid.attach(experimental_check, 1, 2, 1, 1)
+        self.add_row(grid, 0, branch_label, branch_entry)
+        self.add_row(grid, 1, url_label, url_entry)
+        self.add_row(grid, 2, ignore_main_label, ignore_main_check)
+        self.add_row(grid, 3, experimental_label, experimental_check)
 
         self.get_content_area().pack_end(grid, False, False, 0)
 
@@ -530,6 +534,10 @@ class SettingsDialog(Gtk.Dialog):
             write_user_config()
 
         self.connect("response", handle_response)
+
+    def add_row(self, grid, row, label, widget):
+        grid.attach(label, 0, row, 1, 1)
+        grid.attach(widget, 1, row, 1, 1)
 
     def _register_setting(self, key, widget):
         """
@@ -561,7 +569,7 @@ class SettingsDialog(Gtk.Dialog):
         # Add more widget types here as appropriate
         return None
 
-    def get_settings(self):
+    def get_all_settings(self):
         """
         Retrieves a mapping of all settings.
         """

--- a/roles/common/templates/uug_ansible_wrapper.py
+++ b/roles/common/templates/uug_ansible_wrapper.py
@@ -43,6 +43,9 @@ COURSES = {
     "CS 430": "cs430",
     "CS 432": "cs432",
 }
+EXPERIMENTAL_COURSES = {
+    "CS 354": "cs354",
+}
 USER_CONFIG_PATH = os.path.join(os.environ["HOME"], ".config", "vm_config")
 USER_CONFIG = {
     "git_branch": None,
@@ -51,9 +54,11 @@ USER_CONFIG = {
     "roles_all_time": ["common"],
     # Roles to be used for this particular run
     "roles_this_run": ["common"],
+    # Allow experimental courses to be shown
+    "allow_experimental": False,
 }
 NAME = "JMU CS VM Configuration"
-VERSION = "Spring 2019"
+VERSION = "Fall 2021"
 
 
 def main():
@@ -147,26 +152,9 @@ class AnsibleWrapperWindow(Gtk.Window):
 
         contents.pack_start(label, False, False, 0)
 
-        courses_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
-
-        # This button doesn't do anything. Common is always run
-        refresh = Gtk.CheckButton(label="Base configuration")
-        refresh.set_tooltip_text("This option is required")
-        refresh.set_active(True)
-        refresh.set_sensitive(False)
-        courses_box.pack_start(refresh, False, False, 0)
-
-        # Add a checkbox for every course; sorting is necessary because
-        # dictionaries do not guarantee that order is preserved
-        for (course, tag) in sorted(COURSES.items()):
-            checkbox = Gtk.CheckButton(label=course)
-            checkbox.set_tooltip_text(f"Configure for {course}")
-            courses_box.pack_start(checkbox, False, False, 0)
-            if tag in USER_CONFIG["roles_this_run"]:
-                checkbox.set_active(True)
-            checkbox.connect("toggled", self.on_course_toggled, tag)
-            self.checkboxes.append(checkbox)
-        contents.pack_start(courses_box, False, False, 0)
+        self.courses_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+        self.add_all_courses()
+        contents.pack_start(self.courses_box, False, False, 0)
 
         # Add run and cancel buttons
         button_box = Gtk.Box(spacing=6)
@@ -190,6 +178,42 @@ class AnsibleWrapperWindow(Gtk.Window):
         self.terminal.connect("child-exited", self.sub_command_exited)
         contents.pack_end(self.terminal, True, True, 0)
         self.vbox.pack_end(contents, True, True, 0)
+
+    def add_all_courses(self):
+        """
+        Add all courses the window through the checkbox list.
+        """
+        # Remove the existing elements
+        for child in self.courses_box.get_children():
+            child.destroy()
+        self.checkboxes.clear()
+
+        # This button doesn't do anything. Common is always run
+        refresh = Gtk.CheckButton(label="Base configuration")
+        refresh.set_tooltip_text("This option is required")
+        refresh.set_active(True)
+        refresh.set_sensitive(False)
+        self.courses_box.pack_start(refresh, False, False, 0)
+
+        def add_course(course, tag, experimental=False):
+            if experimental and not USER_CONFIG["allow_experimental"]:
+                return
+            checkbox = Gtk.CheckButton(label=course)
+            checkbox.set_tooltip_text(f"Configure for {course}")
+            self.courses_box.pack_start(checkbox, False, False, 0)
+            if tag in USER_CONFIG["roles_this_run"]:
+                checkbox.set_active(True)
+            checkbox.connect("toggled", self.on_course_toggled, tag)
+            self.checkboxes.append(checkbox)
+
+        # Add a checkbox for every course; sorting is necessary because
+        # dictionaries do not guarantee that order is preserved
+        for (course, tag) in sorted(COURSES.items()):
+            add_course(course, tag, experimental=False)
+        if USER_CONFIG["allow_experimental"]:
+            for (course, tag) in sorted(EXPERIMENTAL_COURSES.items()):
+                add_course(f"{course} ⚠️Experimental⚠️", tag, experimental=True)
+        self.courses_box.show_all()
 
     @classmethod
     def on_course_toggled(cls, button, name):
@@ -247,47 +271,10 @@ class AnsibleWrapperWindow(Gtk.Window):
         Displays a dialog for changing the program's settings.
         """
 
-        dialog = Gtk.Dialog(title="Settings", parent=self, modal=True)
-        grid = Gtk.Grid()
-        branch_label = Gtk.Label(label="Branch:")
-        branch_label.set_justify(Gtk.Justification.RIGHT)
-        branch_label.set_halign(Gtk.Align.END)
-
-        url_label = Gtk.Label(label="URL:")
-        url_label.set_justify(Gtk.Justification.RIGHT)
-        url_label.set_halign(Gtk.Align.END)
-
-        branch_field = Gtk.Entry()
-        url_field = Gtk.Entry()
-        branch_field.set_text(USER_CONFIG["git_branch"])
-        url_field.set_text(USER_CONFIG["git_url"])
-        branch_field.set_width_chars(40)
-        url_field.set_width_chars(40)
-
-        grid.add(branch_label)
-        grid.attach_next_to(branch_field, branch_label, Gtk.PositionType.RIGHT, 1, 1)
-        grid.attach_next_to(url_label, branch_label, Gtk.PositionType.BOTTOM, 1, 1)
-        grid.attach_next_to(url_field, url_label, Gtk.PositionType.RIGHT, 1, 1)
-        dialog.get_content_area().pack_end(grid, False, False, 0)
-        ok_button = dialog.add_button(Gtk.STOCK_OK, Gtk.ResponseType.OK)
-        dialog.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
-
-        def click_ok(_):
-            ok_button.clicked()
-
-        branch_field.connect("activate", click_ok)
-        url_field.connect("activate", click_ok)
-        dialog.set_default_size(400, 100)
-        grid.set_row_spacing(6)
-        grid.set_column_spacing(6)
-        grid.set_border_width(6)
-        grid.show_all()
-
+        dialog = SettingsDialog(parent=self)
         response = dialog.run()
         if response == Gtk.ResponseType.OK:
-            USER_CONFIG["git_branch"] = branch_field.get_text()
-            USER_CONFIG["git_url"] = url_field.get_text()
-            write_user_config()
+            self.add_all_courses()
         dialog.destroy()
 
     def show_about_dialog(self, _):
@@ -299,7 +286,7 @@ class AnsibleWrapperWindow(Gtk.Window):
         about_dialog.set_logo_icon_name("{{ tux_icon_name }}")
         about_dialog.set_transient_for(self)
         about_dialog.set_program_name(NAME)
-        about_dialog.set_copyright("Copyright \xa9 2018 JMU Unix Users Group")
+        about_dialog.set_copyright("Copyright \xa9 2018-2021 JMU Unix Users Group")
         about_dialog.set_comments(
             "A tool for configuring virtual machines for use in the "
             "JMU Department of Computer Science, "
@@ -483,6 +470,135 @@ class AnsibleWrapperWindow(Gtk.Window):
             except GLib.Error as error:
                 logging.error("Unable to run ansible command.", exc_info=error)
                 self.sub_command_exited(None, 1)
+
+
+class SettingsDialog(Gtk.Dialog):
+    """
+    Settings dialog window for the configuration tool.
+    """
+
+    def __init__(self, parent):
+        Gtk.Dialog.__init__(self, "Settings", parent, 0)
+        self.add_buttons(
+            Gtk.STOCK_CANCEL,
+            Gtk.ResponseType.CANCEL,
+            Gtk.STOCK_OK,
+            Gtk.ResponseType.OK,
+        )
+
+        self._settings = {}
+        self.set_default_size(400, 100)
+
+        # Use a grid so that the labels and entries can be aligned correctly.
+        grid = Gtk.Grid()
+        grid.set_row_spacing(6)
+        grid.set_column_spacing(6)
+        grid.set_border_width(6)
+
+        branch_label = self._create_label("Release track:")
+        url_label = self._create_label("Source URL:")
+        experimental_label = self._create_label("Experimental:")
+
+        branch_entry = self._create_entry(USER_CONFIG["git_branch"])
+        url_entry = self._create_entry(USER_CONFIG["git_url"])
+        experimental_check = self._create_checkbox(
+            "Allow running unsupported/experimental courses",
+            USER_CONFIG["allow_experimental"],
+        )
+
+        self._register_setting("git_branch", branch_entry)
+        self._register_setting("git_url", url_entry)
+        self._register_setting("allow_experimental", experimental_check)
+
+        grid.attach(branch_label, 0, 0, 1, 1)
+        grid.attach(branch_entry, 1, 0, 1, 1)
+        grid.attach(url_label, 0, 1, 1, 1)
+        grid.attach(url_entry, 1, 1, 1, 1)
+        grid.attach(experimental_label, 0, 2, 1, 1)
+        grid.attach(experimental_check, 1, 2, 1, 1)
+
+        self.get_content_area().pack_end(grid, False, False, 0)
+
+        grid.show_all()
+
+        def handle_response(_, response):
+            if response != Gtk.ResponseType.OK:
+                return
+
+            for key in self._settings:
+                USER_CONFIG[key] = self.get_setting(key)
+            write_user_config()
+
+        self.connect("response", handle_response)
+
+    def _register_setting(self, key, widget):
+        """
+        Registers a setting and its associated GTK widget. This allows it to
+        be retrieved by the settings key later.
+        """
+
+        self._settings[key] = widget
+
+    def get_setting(self, key):
+        """
+        Retrieves the value associated with a particular setting. This allows
+        for the caller to get the value the user chose.
+        """
+
+        widget = self._settings.get(key, None)
+        if widget is None:
+            return None
+
+        if isinstance(widget, Gtk.Entry):
+            # The docs say that the string returned from get_text() should not
+            # be freed, modified, nor stored. It is unclear if this is a
+            # relic from C++, but to be safe, we'll make a copy of the string
+            # and return that to the caller.
+            return str(widget.get_text())
+        if isinstance(widget, Gtk.CheckButton):
+            return widget.get_active()
+
+        # Add more widget types here as appropriate
+        return None
+
+    def get_settings(self):
+        """
+        Retrieves a mapping of all settings.
+        """
+        return {key: self.get_setting(key) for key in self._settings}
+
+    @staticmethod
+    def _create_label(text):
+        """
+        Helps with creating a GTK Label. Sets the text to the given text and then
+        right-justifies the text.
+        """
+
+        label = Gtk.Label(label=text)
+        label.set_justify(Gtk.Justification.RIGHT)
+        label.set_halign(Gtk.Align.END)
+        return label
+
+    @staticmethod
+    def _create_entry(text, width=40):
+        """
+        Creates a GTK Entry widget with the given width and default text.
+        """
+
+        entry = Gtk.Entry()
+        entry.set_text(text)
+        entry.set_width_chars(width)
+        return entry
+
+    @staticmethod
+    def _create_checkbox(text, checked):
+        """
+        Creates a GTK Check Button widget
+        """
+
+        checkbox = Gtk.CheckButton(label=text)
+        checkbox.set_active(checked)
+        return checkbox
 
 
 def on_dialog_close(action, _):


### PR DESCRIPTION
This performs some fairly significant refactoring to the wrapper script. It's incomplete but I am opening it as a draft early to collect additional ideas or objections.

- [X] Experimental course support
- [X] Add Settings for all config values
- [X] Properly follow XDG Base Directory standard
- [X] Use YAML instead of JSON
- [x] ~Improve error message logic~
- [x] ~Improve UX of VTE~
- [x] Link to VM readme in Help menu
- [x] Investigate `sudo` + `AskPass` helper instead of `pkexec`
  - Would make it easier to target which steps run with `become`