### PR TITLE
Update Mint release to Una 20.3

### DIFF
--- a/packer/mint-build.json
+++ b/packer/mint-build.json
@@ -2,8 +2,8 @@
   "min_packer_version": "1.6.0",
   "variables": {
     "vm_name": "JMU Linux Mint",
-    "semester": "Fa21",
-    "version": "20.2",
+    "semester": "Sp22",
+    "version": "20.3",
 
     "build_id": "{{isotime \"2006-01-02\"}}",
 


### PR DESCRIPTION
Survived the first Packer build, no further testing yet.