### PR TITLE
Update Eclipse to 2022-03

### DIFF
--- a/roles/eclipse/vars/main.yml
+++ b/roles/eclipse/vars/main.yml
@@ -3,11 +3,11 @@
 eclipse:
   # Ensure the URL does not specify a mirror and that &r=1 is at the end, which
   # directly links to the file and not the web page with a download button
-  url: 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/2021-12/R/eclipse-java-2021-12-R-linux-gtk-{{ ansible_architecture }}.tar.gz&r=1'
-  url_backup: 'https://download.eclipse.org/technology/epp/downloads/release/2021-12/R/eclipse-java-2021-12-R-linux-gtk-{{ ansible_architecture }}.tar.gz'
+  url: 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/2022-03/R/eclipse-java-2022-03-R-linux-gtk-{{ ansible_architecture }}.tar.gz&r=1'
+  url_backup: 'https://download.eclipse.org/technology/epp/downloads/release/2022-03/R/eclipse-java-2022-03-R-linux-gtk-{{ ansible_architecture }}.tar.gz'
   hash:
-    x86_64: '688f2ee538aeaebae019eeaa8ce3bea1b627830c'
-    aarch64: 'baec7f03f1ad975bc2ca33b0157611bf96207028'
+    x86_64: '986d3d9375d37cba4cfcf6a73c7dff60483228ba'
+    aarch64: '7d4f37f49635673ae62c6c061c55fca48f789818'
   zip: '{{ global_base_path }}/eclipse.tar.gz'
   install_path: '{{ global_base_path }}/eclipse'
 


### PR DESCRIPTION
This version was released on March 16. Hopefully the mirrors have had
time to catch up.
