### PR TITLE
Add SPICE tools

### DIFF
--- a/roles/oem/tasks/vm_only_post.yml
+++ b/roles/oem/tasks/vm_only_post.yml
@@ -13,6 +13,12 @@
   notify:
     - Update dconf database
 
+- name: Install spice agent
+  apt:
+    name: spice-vdagent
+    state: latest
+  when: "ansible_virtualization_type == 'kvm' or ansible_virtualization_type == 'qemu'"
+
 - name: Set debconf grub install_devices
   ansible.builtin.debconf:
     name: grub-pc

--- a/roles/oem/tasks/vm_only_post.yml
+++ b/roles/oem/tasks/vm_only_post.yml
@@ -14,8 +14,10 @@
     - Update dconf database
 
 - name: Install spice agent
-  apt:
-    name: spice-vdagent
+  ansible.builtin.apt:
+    name:
+      - spice-vdagent
+      - spice-webdavd
     state: latest
   when: "ansible_virtualization_type == 'kvm' or ansible_virtualization_type == 'qemu'"
 


### PR DESCRIPTION
This pulls a commit from #457 and also adds `spice-webdavd` per https://mac.getutm.app/support/ to support folder sharing.

I want to play around a bit with packaging for `libvirt` and other tools and having this shared code already in `main` would probably help both branches.

I was tempted to remove the `when` on this, to just always install in a VM since the SPICE tools aren't all that heavy and it shouldn't hurt the VBox builds to have them installed.