### PR TITLE
Revert "Remove prefix for shell, command, and dconf steps"

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,7 +1,7 @@
 ---
 skip_list:
+  # Package installs should not use latest
   - package-latest
 warn_list:
-  - fqcn-builtins
   - ignore-errors
   - experimental

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
 # handlers file for common
 - name: Update icon cache
-  command: /usr/sbin/update-icon-caches /usr/share/icons/*
+  ansible.builtin.command: /usr/sbin/update-icon-caches /usr/share/icons/*

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -9,7 +9,7 @@
     ubuntu_release: "{{ lookup('ini', 'UBUNTU_CODENAME type=properties file=/etc/os-release') }}"
 
 - name: Process all pending installs
-  command: /usr/bin/dpkg --configure -a
+  ansible.builtin.command: /usr/bin/dpkg --configure -a
   register: dpkg_command
   changed_when: dpkg_command.stdout
   environment:

--- a/roles/eclipse/tasks/main.yml
+++ b/roles/eclipse/tasks/main.yml
@@ -42,7 +42,7 @@
         mode: "0755"
   when: st.stat.checksum|default("") != eclipse.hash[ansible_architecture]
 - name: Install checkstyle plugin
-  command: >
+  ansible.builtin.command: >
     {{ eclipse.install_path }}/eclipse
     -nosplash
     -application org.eclipse.equinox.p2.director

--- a/roles/jgrasp/tasks/main.yml
+++ b/roles/jgrasp/tasks/main.yml
@@ -36,12 +36,12 @@
 - name: Configure and build jGRASP wedge
   block:
     - name: Configure jGRASP wedge build
-      command:
+      ansible.builtin.command:
         cmd: './configure'
         creates: '{{ jgrasp.install_path }}/src/Make.sh'
         chdir: '{{ jgrasp.install_path }}/src/'
     - name: Make and install jGRASP wedge
-      command:
+      ansible.builtin.command:
         cmd: './Make.sh'
         creates: '{{ jgrasp.install_path }}/internal_bin/sys_run'
         chdir: '{{ jgrasp.install_path }}/src'

--- a/roles/oem/handlers/main.yml
+++ b/roles/oem/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
 # handlers file for oem
 - name: Update dconf database
-  command:
+  ansible.builtin.command:
     cmd: /usr/bin/dconf update

--- a/roles/oem/tasks/mint_only.yml
+++ b/roles/oem/tasks/mint_only.yml
@@ -6,8 +6,9 @@
     name: "{{ upgrade_pre_mintupdate }}"
     state: latest
 - name: Upgrade all installed packages  # noqa no-changed-when
-  command:
+  ansible.builtin.command:
     cmd: /usr/bin/mintupdate-cli -y upgrade
+
 - name: Ensure skeleton desktop directory exists
   ansible.builtin.file:
     path: "{{ skel_desktop_file_path }}"

--- a/roles/oem/tasks/ubuntu_only.yml
+++ b/roles/oem/tasks/ubuntu_only.yml
@@ -5,10 +5,10 @@
   ansible.builtin.apt:
     upgrade: safe
 - name: Upgrade all installed snaps  # noqa no-changed-when
-  command:
+  ansible.builtin.command:
     cmd: snap refresh
 - name: Purge old snaps
-  shell: |
+  ansible.builtin.shell: |
     set -o pipefail
     errors=0
     changed=""

--- a/roles/oem/tasks/vm_only_post.yml
+++ b/roles/oem/tasks/vm_only_post.yml
@@ -38,7 +38,7 @@
 # The apt database can be fairly large and make the image unnecessarily large
 # so removing it before shipping allows us to ship a smaller image.
 - name: Clean the apt package cache
-  command:
+  ansible.builtin.command:
     cmd: apt-get clean
   # This will always report as changed otherwise
   changed_when: false
@@ -62,13 +62,13 @@
 # Extensions which are non-free software and available only under the Oracle
 # PUEL. We should ensure we have not accidentally included them.
 - name: Validate missing USB 2/3 controllers  # noqa risky-shell-pipe
-  command:
+  ansible.builtin.command:
     cmd: lspci
   register: lspci_output
   failed_when: "'ECHI' in lspci_output.stdout or 'xHCI' in lspci_output.stdout"
   changed_when: false
 
 - name: Fill disk with zeros to assist with compression
-  shell:
+  ansible.builtin.shell:
     cmd: dd if=/dev/zero of=/bigfile bs=1M; sync; rm /bigfile
   changed_when: false

--- a/roles/user/handlers/main.yml
+++ b/roles/user/handlers/main.yml
@@ -1,10 +1,10 @@
 ---
 # handlers file for user
 - name: Update desktop menu
-  command:
+  ansible.builtin.command:
     cmd: /usr/bin/update-desktop-database
 - name: Suggest restart
-  command:
+  ansible.builtin.command:
     cmd: >-
       notify-send -u critical "JMU Software Change"
       "Changes have been made to your machine that

--- a/roles/user/tasks/main.yml
+++ b/roles/user/tasks/main.yml
@@ -95,7 +95,7 @@
   ignore_errors: yes
   loop: "{{ real_users }}"
 - name: Remove Timeshift warning
-  dconf:
+  community.general.dconf:
     key: "/com/linuxmint/updates/warn-about-timeshift"
     value: "false"
     state: present
@@ -104,7 +104,7 @@
   loop: "{{ real_users }}"
   when: "ansible_distribution == 'Linux Mint'"
 - name: Remove mintupdate welcome page
-  dconf:
+  community.general.dconf:
     key: "/com/linuxmint/updates/show-welcome-page"
     value: "false"
     state: present

--- a/roles/vscode/tasks/main.yml
+++ b/roles/vscode/tasks/main.yml
@@ -16,7 +16,7 @@
     name: 'code'
     state: latest
 - name: Install Java pack plugin
-  command:
+  ansible.builtin.command:
     cmd: /usr/bin/code --install-extension vscjava.vscode-java-pack
   args:
     creates: '{{ item.homedir }}/.vscode/extensions/vscjava.vscode-java-pack*'
@@ -24,7 +24,7 @@
   become_user: "{{ item.user }}"
   loop: "{{ real_users }}"
 - name: Install checkstyle plugin
-  command:
+  ansible.builtin.command:
     cmd: /usr/bin/code --install-extension shengchen.vscode-checkstyle
   args:
     creates: '{{ item.homedir }}/.vscode/extensions/shengchen.vscode-checkstyle*'

--- a/roles/wireless_printing/tasks/main.yml
+++ b/roles/wireless_printing/tasks/main.yml
@@ -14,7 +14,7 @@
 # Do not indent continuation lines of a multi-line block,
 # they become newlines when parsed
 - name: Add printers
-  shell: >
+  ansible.builtin.shell: >
     lpstat -p "{{ item.name }}" ||
     lpadmin -p "{{ item.name }}" -E
     -v "{{ item.queue }}"


### PR DESCRIPTION
Now that we're working on Ubuntu 22.04, we no longer need to suppress old lint warnings.

This reverts commit 485842b7344e92ac02808a3940b188fc084d9b8e.