### PR TITLE
Fix the Ubuntu update workflow to work with HCL

### DIFF
--- a/.github/workflows/auto-update-iso.yml
+++ b/.github/workflows/auto-update-iso.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 9 * * *'
   workflow_dispatch:
 env:
-  UBUNTU_RELEASE: focal
+  UBUNTU_RELEASE: jammy
 jobs:
   update-ubuntu:
     if: github.repository == 'jmunixusers/cs-vm-build'
@@ -18,18 +18,7 @@ jobs:
           sudo apt-get install -q -y jq
       - name: Set latest ISO name
         id: iso
-        run: |
-          MIRROR_URL="https://mirror.cs.jmu.edu/pub/ubuntu-iso/$UBUNTU_RELEASE"
-          ISO_NAME="$(curl -sL "$MIRROR_URL/SHA256SUMS" | grep desktop | head -n 1 | cut -d'*' -f 2)"
-          VERSION="$(echo "$ISO_NAME" | cut -d'-' -f 2)"
-          jq \
-            --arg iso "$ISO_NAME" \
-            --arg mirror "$MIRROR_URL" \
-            '.variables.iso_file = $iso | .variables.mirror_url = $mirror' packer/ubuntu-build.json > packer/ubuntu-build-update.json
-          mv packer/ubuntu-build-update.json packer/ubuntu-build.json
-          echo "::set-output name=version::$VERSION"
-          echo "::set-output name=iso_file::$ISO_NAME"
-          echo "::set-output name=mirror_url::$MIRROR_URL"
+        run: ./scripts/update-ubuntu-release
       - name: Open a pull request
         uses: peter-evans/create-pull-request@v4
         with:

--- a/packer/ubuntu-version.auto.pkrvars.hcl
+++ b/packer/ubuntu-version.auto.pkrvars.hcl
@@ -1,0 +1,4 @@
+ubuntu_version = {
+  version = "jammy"
+  patched_version = "22.04"
+}

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -11,13 +11,11 @@ variable "mint_version" {
 
 variable "ubuntu_version" {
   type = object({
-    version       = string
-    minor_version = string
+    version = string
+    patched_version = string
   })
-  default = {
-    version       = "22.04"
-    minor_version = ""
-  }
+  # The default value for this is stored in ubuntu-version.auto.pkrvars.hcl, which will be
+  # updated by the GitHub Actions workflow that automatically updates the Ubuntu version.
 }
 
 variable "mirror" {
@@ -77,7 +75,7 @@ locals {
   build_id = "${legacy_isotime("2006-01-02")}"
   ubuntu_info = {
     mirror_url = "${var.mirror.base}/${var.mirror.ubuntu_path}/${var.ubuntu_version.version}"
-    iso_file   = "ubuntu-${var.ubuntu_version.version}${var.ubuntu_version.minor_version}-desktop-amd64.iso"
+    iso_file   = "ubuntu-${var.ubuntu_version.patched_version}-desktop-amd64.iso"
   }
   mint_info = {
     mirror_url = "${var.mirror.base}/${var.mirror.mint_path}/${var.mint_version.beta ? "testing" : "stable/${var.mint_version.version}"}"

--- a/scripts/update-ubuntu-release
+++ b/scripts/update-ubuntu-release
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+MIRROR_URL="https://mirror.cs.jmu.edu/pub/ubuntu-iso/$UBUNTU_RELEASE"
+ISO_NAME="$(curl -sL "$MIRROR_URL/SHA256SUMS" | grep desktop | head -n 1 | cut -d'*' -f 2)"
+VERSION="$(echo "$ISO_NAME" | cut -d'-' -f 2)"
+cat << EOF > packer/ubuntu-version.auto.pkrvars.hcl
+ubuntu_version = {
+  version = "$UBUNTU_RELEASE"
+  patched_version = "$VERSION"
+}
+EOF
+echo "::set-output name=version::$VERSION"
+echo "::set-output name=iso_file::$ISO_NAME"
+echo "::set-output name=mirror_url::$MIRROR_URL"


### PR DESCRIPTION
The change to HCL broke the update workflow because it's not JSON and
the JSON file we were parsing was deleted. This uses an
`auto.pkrvars.hcl` file to set the Ubuntu version (for which an updated
version is intentionally not committed so that the workflow will have
work to do). This means that check will fail until the workflow runs and
opens its own PR (becuse validation fails if the checksum can't be
found).

This is done _in addition_ to `version` so that the the friendlier
version can be used in contexts where the patch version doesn't really
matter (like the parent directory or the build metadata).
