### PR TITLE
Fix Packer formatting in update workflow

### DIFF
--- a/packer/ubuntu-version.auto.pkrvars.hcl
+++ b/packer/ubuntu-version.auto.pkrvars.hcl
@@ -1,4 +1,4 @@
 ubuntu_version = {
-  version = "jammy"
+  version         = "jammy"
   patched_version = "22.04.1"
 }

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -11,7 +11,7 @@ variable "mint_version" {
 
 variable "ubuntu_version" {
   type = object({
-    version = string
+    version         = string
     patched_version = string
   })
   # The default value for this is stored in ubuntu-version.auto.pkrvars.hcl, which will be

--- a/scripts/update-ubuntu-release
+++ b/scripts/update-ubuntu-release
@@ -5,7 +5,7 @@ ISO_NAME="$(curl -sL "$MIRROR_URL/SHA256SUMS" | grep desktop | head -n 1 | cut -
 VERSION="$(echo "$ISO_NAME" | cut -d'-' -f 2)"
 cat << EOF > packer/ubuntu-version.auto.pkrvars.hcl
 ubuntu_version = {
-  version = "$UBUNTU_RELEASE"
+  version         = "$UBUNTU_RELEASE"
   patched_version = "$VERSION"
 }
 EOF


### PR DESCRIPTION
Oops. Not caught on the PRs but on the merge to main. I ran
`packer validate` but not `fmt`...
