### PR TITLE
Explicitly use Ubuntu 22.04 in workflows

### DIFF
--- a/.github/workflows/auto-update-iso.yml
+++ b/.github/workflows/auto-update-iso.yml
@@ -10,7 +10,7 @@ jobs:
   update-ubuntu:
     if: github.repository == 'jmunixusers/cs-vm-build'
     name: Update Ubuntu ISO file name
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   Ansible:
     name: Run Ansible lint tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.x
@@ -26,7 +26,7 @@ jobs:
           yamllint .github/workflows/*yml
   Packer:
     name: Run Packer lint tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -54,7 +54,7 @@ jobs:
         working-directory: packer
   Python:
     name: Run Python lint tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -74,7 +74,7 @@ jobs:
           pylint roles/*/*/*.py scripts/*.py
   Shell:
     name: Run Shell linting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@master
@@ -89,7 +89,7 @@ jobs:
           shellcheck --shell=bash scripts/oem-build roles/user/files/csvmprofile
   Hashes:
     name: Validate file hashes
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
We had been using 20.04 and while the 22.04 runner is now GA, it is not
yet the default for `ubuntu-latest`. And even if it were, we were still
hardcoding 20.04 anyway. Because we've updated the version of Mint and
of Ubuntu used within the config, we should update the workflows to
match.
