### PR TITLE
Fix typo in Mint dconf file

### DIFF
--- a/roles/oem/tasks/mint_only.yml
+++ b/roles/oem/tasks/mint_only.yml
@@ -37,7 +37,7 @@
     mode: "0755"
 - name: Copy dconf config file
   ansible.builtin.copy:
-    src: csconfig-vmonly
+    src: csconfig-mintonly
     dest: /etc/dconf/db/local.d/csconfig-mintonly
     owner: root
     group: root


### PR DESCRIPTION
I'm dumb and let this slip in the PR yesterday