### PR TITLE
Use new GitHub Actions output mechanism

### DIFF
--- a/scripts/update-ubuntu-release
+++ b/scripts/update-ubuntu-release
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+set-output() (
+  local name="$1"
+  local value="$2"
+  # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
+  echo "$name=$value" >> "$GITHUB_OUTPUT"
+)
+
 MIRROR_URL="https://mirror.cs.jmu.edu/pub/ubuntu-iso/$UBUNTU_RELEASE"
 ISO_NAME="$(curl -sL "$MIRROR_URL/SHA256SUMS" | grep desktop | head -n 1 | cut -d'*' -f 2)"
 VERSION="$(echo "$ISO_NAME" | cut -d'-' -f 2)"
@@ -9,6 +16,7 @@ ubuntu_version = {
   patched_version = "$VERSION"
 }
 EOF
-echo "::set-output name=version::$VERSION"
-echo "::set-output name=iso_file::$ISO_NAME"
-echo "::set-output name=mirror_url::$MIRROR_URL"
+
+set-output "version" "$VERSION"
+set-output "iso_file" "$ISO_NAME"
+set-output "mirror_url" "$MIRROR_URL"


### PR DESCRIPTION
GitHub has [recently deprececated][deprecation notice] the `set-output`
function in workflows, instead having users switch to to using a newly
created environment file for this purpose. Because this is confusing,
the behavior is extracted to a function that we can reuse.

[deprecation notice]: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
