### PR TITLE
Fix Ansible Lint

### DIFF
--- a/lintrules/ansible/ModeIsString.py
+++ b/lintrules/ansible/ModeIsString.py
@@ -2,14 +2,18 @@ from typing import Any, Dict, Union
 
 import ansiblelint.utils
 from ansiblelint.rules import AnsibleLintRule
+from ansiblelint.file_utils import Lintable
 
 class ModeIsString(AnsibleLintRule):
+    """
+    mode must be a string
+    """
+
     id = "mode-is-string"
-    shortdesc = "mode must be a string"
     description = "File and directory modes must be strings"
     tags = ['idiom']
 
-    def matchtask(self, task: Dict[str, Any]) -> Union[bool, str]:
+    def matchtask(self, task: Dict[str, Any], file: Lintable | None = None) -> bool | str:
         # Tasks without a mode should not be matched
         if "action" not in task:
             return False

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -57,9 +57,11 @@
     dest: "{{ wrapper_desktop_file_path }}/jmucs_config.desktop"
     mode: "0755"
 
-- include_tasks: ubuntu_only.yml
+- name: Load Ubuntu tasks
+  ansible.builtin.include_tasks: ubuntu_only.yml
   when: "ansible_distribution == 'Ubuntu'"
-- include_tasks: mint_only.yml
+- name: Load Mint tasks
+  ansible.builtin.include_tasks: mint_only.yml
   when: "ansible_distribution == 'Linux Mint'"
 - name: Refresh apt cache
   ansible.builtin.apt:

--- a/roles/eclipse/tasks/main.yml
+++ b/roles/eclipse/tasks/main.yml
@@ -9,6 +9,7 @@
     path: '{{ eclipse.zip }}'
   register: st
 - name: Download and unpack Eclipse
+  when: st.stat.checksum | default("") != eclipse.hash[ansible_architecture]
   block:
     - name: Fetch Eclipse bundle
       ansible.builtin.get_url:
@@ -40,7 +41,6 @@
         owner: root
         group: root
         mode: "0755"
-  when: st.stat.checksum | default("") != eclipse.hash[ansible_architecture]
 - name: Install checkstyle plugin
   ansible.builtin.command: >
     {{ eclipse.install_path }}/eclipse

--- a/roles/oem/tasks/main.yml
+++ b/roles/oem/tasks/main.yml
@@ -1,7 +1,8 @@
 ---
 # tasks file for oem
 
-- include_tasks: vm_only_pre.yml
+- name: Load VM-specific early run tasks
+  ansible.builtin.include_tasks: vm_only_pre.yml
   when: "ansible_virtualization_role == 'guest'"
 - name: Remove unused dependencies
   ansible.builtin.apt:
@@ -34,11 +35,14 @@
     mode: "0755"
     owner: root
 
-- include_tasks: ubuntu_only.yml
+- name: Load Ubuntu tasks
+  ansible.builtin.include_tasks: ubuntu_only.yml
   when: "ansible_distribution == 'Ubuntu'"
-- include_tasks: mint_only.yml
+- name: Load Mint tasks
+  ansible.builtin.include_tasks: mint_only.yml
   when: "ansible_distribution == 'Linux Mint'"
 
 # Some tasks should only be run when running as a guest OS.
-- include_tasks: vm_only_post.yml
+- name: Load VM-specific late run tasks
+  ansible.builtin.include_tasks: vm_only_post.yml
   when: "ansible_virtualization_role == 'guest'"


### PR DESCRIPTION
This makes a few fixes based on recent changes to Ansible Lint. `name`s
are added to all `import_tasks` which also now use the fully-qualified
name `ansible.builtin.import_tasks`. The custom lint rule is also
updated to meet the new type requirements (previously it was failing due
to being passed an unexpected argument, `file`).
