### PR TITLE
Fix errors in `ansible-lint`

### DIFF
--- a/roles/adv_prog_pkgs/tests/test.yml
+++ b/roles/adv_prog_pkgs/tests/test.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: localhost
+  name: Test adv_prog_pkgs
   remote_user: root
   roles:
     - adv_prog_pkgs

--- a/roles/adv_prog_pkgs/tests/test.yml
+++ b/roles/adv_prog_pkgs/tests/test.yml
@@ -2,4 +2,4 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - adv-prog-pkgs
+    - adv_prog_pkgs

--- a/roles/basic_prog_pkgs/tests/test.yml
+++ b/roles/basic_prog_pkgs/tests/test.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: localhost
+  name: Test basic_prog_pkgs
   remote_user: root
   roles:
     - basic_prog_pkgs

--- a/roles/basic_prog_pkgs/tests/test.yml
+++ b/roles/basic_prog_pkgs/tests/test.yml
@@ -2,4 +2,4 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - basic-prog-pkgs
+    - basic_prog_pkgs

--- a/roles/common/tests/test.yml
+++ b/roles/common/tests/test.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: localhost
+  name: Test common
   remote_user: root
   roles:
     - common

--- a/roles/eclipse/tests/test.yml
+++ b/roles/eclipse/tests/test.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: localhost
+  name: Test eclipse
   remote_user: root
   roles:
     - eclipse

--- a/roles/filezilla/tests/test.yml
+++ b/roles/filezilla/tests/test.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: localhost
+  name: Test filezilla
   remote_user: root
   roles:
     - filezilla

--- a/roles/oem/tests/test.yml
+++ b/roles/oem/tests/test.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: localhost
+  name: Test oem
   remote_user: root
   roles:
     - oem

--- a/roles/programming_langs/tests/test.yml
+++ b/roles/programming_langs/tests/test.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: localhost
+  name: Test programming_langs
   remote_user: root
   roles:
     - programming_langs

--- a/roles/programming_langs/tests/test.yml
+++ b/roles/programming_langs/tests/test.yml
@@ -2,4 +2,4 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - programming-langs
+    - programming_langs

--- a/roles/user/tests/test.yml
+++ b/roles/user/tests/test.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: localhost
+  name: Test user
   remote_user: root
   roles:
     - user

--- a/roles/vscode/tests/test.yml
+++ b/roles/vscode/tests/test.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: localhost
+  name: Test vscode
   remote_user: root
   roles:
     - vscode

--- a/roles/wireless_printing/tests/test.yml
+++ b/roles/wireless_printing/tests/test.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: localhost
+  name: Test wireless_printing
   remote_user: root
   roles:
     - wireless_printing

--- a/roles/wireless_printing/tests/test.yml
+++ b/roles/wireless_printing/tests/test.yml
@@ -2,4 +2,4 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - wireless-printing
+    - wireless_printing

--- a/roles/y86/tests/test.yml
+++ b/roles/y86/tests/test.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: localhost
+  name: Test y86
   remote_user: root
   roles:
     - y86


### PR DESCRIPTION
It looks like `ansible-lint` recently learned about the `tests/` within
each role. And while I am sure that is good news for a great many
people, we do not run our tests and we also do not have
linter-compliant ones. The rules that we were failing were not
test-specific, so there's nothing to add to the configuration file. We
either needed to remediate the failures or delete the tests. Because
these were fairly basic changes (updating names to match and adding a
`name` field), it seemed worth it to just make the changes. If this
(some day) gets so opinionated as to want us to actually have
meaningful tests then we probably want to go the route of just deleting
the files.
