### PR TITLE
Resolve ansible-lint errors as of version 6.14.4

### DIFF
--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -1,4 +1,6 @@
 ---
 # handlers file for common
 - name: Update icon cache
-  ansible.builtin.command: /usr/sbin/update-icon-caches /usr/share/icons/*
+  ansible.builtin.command:
+    cmd: /usr/sbin/update-icon-caches /usr/share/icons/*
+  changed_when: true

--- a/roles/oem/handlers/main.yml
+++ b/roles/oem/handlers/main.yml
@@ -3,3 +3,4 @@
 - name: Update dconf database
   ansible.builtin.command:
     cmd: /usr/bin/dconf update
+  changed_when: true

--- a/roles/oem/tasks/vm_only_post.yml
+++ b/roles/oem/tasks/vm_only_post.yml
@@ -28,12 +28,8 @@
 # The apt database can be fairly large and make the image unnecessarily large
 # so removing it before shipping allows us to ship a smaller image.
 - name: Clean the apt package cache
-  ansible.builtin.command:
-    cmd: apt-get clean
-  # This will always report as changed otherwise
-  changed_when: false
-  args:
-    warn: no
+  ansible.builtin.apt:
+    clean: true
 
 - name: Find package lists to delete
   ansible.builtin.find:

--- a/roles/user/handlers/main.yml
+++ b/roles/user/handlers/main.yml
@@ -3,6 +3,7 @@
 - name: Update desktop menu
   ansible.builtin.command:
     cmd: /usr/bin/update-desktop-database
+  changed_when: true
 - name: Suggest restart
   ansible.builtin.command:
     cmd: >-
@@ -15,3 +16,4 @@
   become: yes
   become_user: "{{ item.user }}"
   loop: "{{ real_users }}"
+  changed_when: true


### PR DESCRIPTION
For some reason, dependabot ran against my fork overnight and opened this: https://github.com/ripleymj/cs-vm-build/pull/15

That's alerted that we once again have ansible-lint errors. Since the commands occur in handlers that are triggered conditionally, I just marked them all as `changed_when: true`. If anybody wants to investigate them individually further, that's certainly an option. While the handler commands were fatal, I also fixed the `apt-get clean` warning we've been squelching since that functionality is now available natively.

Once this is in, we can address dependabot's actual concern.