### PR TITLE
Allow EHCI and xHCI controllers now that they're open source

### DIFF
--- a/packer/main.pkr.hcl
+++ b/packer/main.pkr.hcl
@@ -47,7 +47,6 @@ source "virtualbox-iso" "base-build" {
     ["modifyvm", "{{.Name}}", "--nat-localhostreachable1", "on"],
     ["modifyvm", "{{ .Name }}", "--mouse", "usbtablet"],
     ["modifyvm", "{{ .Name }}", "--pae", "on"],
-    ["modifyvm", "{{ .Name }}", "--usb", "on", "--usbehci", "off", "--usbxhci", "off"],
     ["modifyvm", "{{ .Name }}", "--vrde", "off"],
     ["storagectl", "{{ .Name }}", "--name", "IDE Controller", "--remove"],
     ["storagectl", "{{ .Name }}", "--name", "SATA Controller", "--hostiocache", "on"]

--- a/roles/oem/tasks/vm_only_post.yml
+++ b/roles/oem/tasks/vm_only_post.yml
@@ -47,16 +47,6 @@
     state: absent
   with_items: "{{ found_package_lists['files'] }}"
 
-# The USB 2/3 controllers are only available with the Virtualbox
-# Extensions which are non-free software and available only under the Oracle
-# PUEL. We should ensure we have not accidentally included them.
-- name: Validate missing USB 2/3 controllers  # noqa risky-shell-pipe
-  ansible.builtin.command:
-    cmd: lspci
-  register: lspci_output
-  failed_when: "'ECHI' in lspci_output.stdout or 'xHCI' in lspci_output.stdout"
-  changed_when: false
-
 - name: Fill disk with zeros to assist with compression
   ansible.builtin.shell:
     cmd: dd if=/dev/zero of=/bigfile bs=1M; sync; rm /bigfile


### PR DESCRIPTION
Still testing this one, but since the USB controllers were open-sourced with the VBox 7 release a year ago, I think it's safe to leave them to their defaults instead of forcing them off.