### PR TITLE
Victoria release

### DIFF
--- a/packer/mint-beta.pkrvars.hcl
+++ b/packer/mint-beta.pkrvars.hcl
@@ -1,6 +1,6 @@
-semester = "Sp23"
+semester = "Fa23"
 
 mint_version = {
-  version = "21.1"
+  version = "21.2"
   beta    = true
 }

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -4,7 +4,7 @@ variable "mint_version" {
     beta    = bool
   })
   default = {
-    version = "21.1"
+    version = "21.2"
     beta    = false
   }
 }
@@ -53,7 +53,7 @@ variable "headless" {
 
 variable "semester" {
   type    = string
-  default = "Sp23"
+  default = "Fa23"
 }
 
 variable "ssh_pass" {

--- a/roles/oem/tasks/vm_only_post.yml
+++ b/roles/oem/tasks/vm_only_post.yml
@@ -27,9 +27,12 @@
 
 # The apt database can be fairly large and make the image unnecessarily large
 # so removing it before shipping allows us to ship a smaller image.
-- name: Clean the apt package cache
-  ansible.builtin.apt:
-    clean: true
+# This should be converted to the apt module clean once we have Ansible 2.13
+- name: Clean the apt package cache  # noqa command-instead-of-module
+  ansible.builtin.command:
+    cmd: apt-get clean
+  # This will always report as changed otherwise
+  changed_when: false
 
 - name: Find package lists to delete
   ansible.builtin.find:


### PR DESCRIPTION
(closed beta PR, in favor of updating all at once because of the shared ansible fix)

Update beta and release variables for Victoria release

Also, revert apt-get clean step that breaks the build, because some fool (https://github.com/jmunixusers/cs-vm-build/pull/523) tried to fix a linter error that requires Ansible 2.13 while we're stuck with 2.10.