### PR TITLE
Fix packer validate plugin error

### DIFF
--- a/packer/main.pkr.hcl
+++ b/packer/main.pkr.hcl
@@ -1,5 +1,11 @@
 packer {
   required_version = ">= 1.7.0"
+  required_plugins {
+    virtualbox = {
+      version = "~> 1"
+      source  = "github.com/hashicorp/virtualbox"
+    }
+  }
 }
 
 source "virtualbox-iso" "base-build" {


### PR DESCRIPTION
It seems like Packer doesn't realize that we need the Virtualbox plugin
when it does the validation.
