### PR TITLE
Update to Mint 21.3 Virginia

### DIFF
--- a/packer/http/oem-preseed.cfg
+++ b/packer/http/oem-preseed.cfg
@@ -36,13 +36,6 @@ d-i partman/choose_partition select finish
 d-i partman/confirm boolean true
 d-i partman/confirm_nooverwrite boolean true
 
-# This is fairly safe to set, it makes grub install automatically to the MBR
-# if no other operating system is detected on the machine.
-d-i grub-installer/only_debian boolean true
-
-# To install to the first device (assuming it is not a USB stick):
-d-i grub-installer/bootdev  string default
-
 ### Clock and time zone setup
 d-i clock-setup/utc boolean true
 d-i time/zone string US/Eastern

--- a/packer/main.pkr.hcl
+++ b/packer/main.pkr.hcl
@@ -16,6 +16,7 @@ source "virtualbox-iso" "base-build" {
   gfx_vram_size = 64
 
   format                   = "ova"
+  firmware                 = "efi"
   gfx_controller           = "vmsvga"
   gfx_accelerate_3d        = true
   hard_drive_discard       = true
@@ -33,17 +34,23 @@ source "virtualbox-iso" "base-build" {
 
   boot_wait = "5s"
   boot_command = [
-    "<esc><wait><esc><wait><esc><wait>",
-    "c<wait>",
-    "linux /casper/vmlinuz fsck.mode=skip<wait> noprompt",
+    # Enter the command line
+    "c<wait><wait>",
+    # Configure the kernel
+    "linux /casper/vmlinuz",
+    " boot=casper",
     " auto url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/oem-preseed.cfg",
-    " automatic-ubiquity noninteractive debug-ubiquity keymap=us<enter>",
+    " automatic-ubiquity only-ubiquity",
+    " debug-ubiquity oem-config/enable=true",
+    " keymap=us fsck.mode=skip",
+    " noprompt splash --<enter><wait><wait>",
+    # Configure initrd & boot
     # Different distributions name (and compress) the initrd differently. Fortunately,
     # GRUB is mostly smart and if the file doesn't exist, it just won't apply that directive.
     # So to prevent duplication, we specify both and let GRUB ignore the wrong one.
-    "initrd /casper/initrd<enter><wait>",
+    "initrd /casper/initrd<enter>",
     "initrd /casper/initrd.lz<enter><wait>",
-    "boot<enter>"
+    "<enter>boot<enter>"
   ]
   shutdown_command = "echo -e \"${var.ssh_pass}\\n\" | sudo -S poweroff"
 

--- a/packer/mint-beta.pkrvars.hcl
+++ b/packer/mint-beta.pkrvars.hcl
@@ -1,6 +1,6 @@
 semester = "Fa23"
 
 mint_version = {
-  version = "21.2"
+  version = "21.3"
   beta    = true
 }

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -4,7 +4,7 @@ variable "mint_version" {
     beta    = bool
   })
   default = {
-    version = "21.2"
+    version = "21.3"
     beta    = false
   }
 }


### PR DESCRIPTION
This updates to Mint 21.3. As part of the release, Mint changed to using
syslinux on BIOS installs. I really don't want to learn how that works
for the boot command so instead, this migrates to UEFI which Mint
promises is better supported in 21.3 and which VirtualBox continually is
improving support for. The boot command gets some minor tweaks but these
match what was planned for QEMU on AARCH64 anyway.

Supersedes #419 