### PR TITLE
Use different name for builder and exported VM

### DIFF
--- a/packer/main.pkr.hcl
+++ b/packer/main.pkr.hcl
@@ -66,7 +66,7 @@ source "virtualbox-iso" "base-build" {
 build {
   source "source.virtualbox-iso.base-build" {
     name             = "mint"
-    vm_name          = "${var.vm_name} Linux Mint ${var.semester}"
+    vm_name          = "${var.vm_name} Linux Mint ${var.semester} Build ${local.build_id}"
     iso_url          = "${local.mint_info.mirror_url}/${local.mint_info.iso_file}"
     iso_checksum     = "file:${local.mint_info.mirror_url}/sha256sum.txt"
     output_filename  = "image-${lower(var.semester)}-mint"
@@ -79,13 +79,14 @@ build {
       "--producturl", "https://linuxmint.com/",
       "--vendor", "JMU Unix Users Group",
       "--vendorurl", "${var.git_repo}",
-      "--version", "${var.mint_version.version}"
+      "--version", "${var.mint_version.version}",
+      "--vmname", "${var.vm_name} Linux Mint ${var.semester}"
     ]
   }
 
   source "source.virtualbox-iso.base-build" {
     name             = "ubuntu"
-    vm_name          = "${var.vm_name} Ubuntu ${var.semester}"
+    vm_name          = "${var.vm_name} Ubuntu ${var.semester} Build ${local.build_id}"
     iso_url          = "${local.ubuntu_info.mirror_url}/${local.ubuntu_info.iso_file}"
     iso_checksum     = "file:${local.ubuntu_info.mirror_url}/SHA256SUMS"
     output_filename  = "image-${lower(var.semester)}-ubuntu"
@@ -98,7 +99,8 @@ build {
       "--producturl", "https://ubuntu.com/",
       "--vendor", "JMU Unix Users Group",
       "--vendorurl", "${var.git_repo}",
-      "--version", "${var.ubuntu_version.version}"
+      "--version", "${var.ubuntu_version.version}",
+      "--vmname", "${var.vm_name} Ubuntu ${var.semester}"
     ]
   }
 

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -72,7 +72,7 @@ variable "vm_name" {
 }
 
 locals {
-  build_id = "${legacy_isotime("2006-01-02")}"
+  build_id = formatdate("YYYY-MM-DD", timestamp())
   ubuntu_info = {
     mirror_url = "${var.mirror.base}/${var.mirror.ubuntu_path}/${var.ubuntu_version.version}"
     iso_file   = "ubuntu-${var.ubuntu_version.patched_version}-desktop-amd64.iso"


### PR DESCRIPTION
This allows building a new VM for the current semester while a previous
build of the same semester is still registered in VirtualBox. It doesn't
help having multiple builds of the same VM going at the same time but it
makes things slightly smoother. The exported VM gets to keep the same
name pattern it's always had via the `vmname` argument to
`VBoxManage export`.

Additionally, the `legacy_isotime` function invocation is replaced with
the recommended migration path.
