### PR TITLE
Enable good USB

### DIFF
--- a/packer/main.pkr.hcl
+++ b/packer/main.pkr.hcl
@@ -67,6 +67,7 @@ source "virtualbox-iso" "base-build" {
   ]
   vboxmanage_post = [
     ["modifyvm", "{{.Name}}", "--nat-localhostreachable1", "off"],
+    ["modifyvm", "{{.Name}}", "--usb-xhci", "on"],
     ["storageattach", "{{ .Name }}", "--storagectl", "VirtIO Controller", "--port", "1", "--type", "dvddrive", "--medium", "emptydrive"]
   ]
 }


### PR DESCRIPTION
We previously started to allow XHCI with them being included in the base VirtualBox and no longer restrictively licensed; let's go ahead and actually turn them on all the way after we're done with the initial build. Even though it's unlikely too many things will get mapped into the VM, it's nice to have a sensible and good default.

I tested this by running a 4K webcam in Mint and it seemed to perform well.