### PR TITLE
Eclipse 2023-12

### DIFF
--- a/roles/eclipse/files/logback.xml
+++ b/roles/eclipse/files/logback.xml
@@ -1,0 +1,4 @@
+<configuration>
+    <logger name="org.apache" level="WARN" />
+    <logger name="httpclient" level="WARN" /> 
+</configuration>

--- a/roles/eclipse/tasks/main.yml
+++ b/roles/eclipse/tasks/main.yml
@@ -41,6 +41,11 @@
         owner: root
         group: root
         mode: "0755"
+- name: Install logback config file
+  ansible.builtin.copy:
+    src: logback.xml
+    dest: '{{ eclipse.install_path }}'
+    mode: "0644"
 - name: Install checkstyle plugin
   ansible.builtin.command: >
     {{ eclipse.install_path }}/eclipse
@@ -49,6 +54,8 @@
     -repository https://checkstyle.org/eclipse-cs-update-site/
     -installIU net.sf.eclipsecs.feature.group
     -destination {{ eclipse.install_path }}
+    -vmargs
+    -Dlogback.configurationFile=file:{{ eclipse.install_path }}/logback.xml
   args:
     creates: '{{ eclipse.install_path }}/plugins/net.sf.eclipsecs.checkstyle*'
 - name: Install Eclipse desktop icon

--- a/roles/eclipse/vars/main.yml
+++ b/roles/eclipse/vars/main.yml
@@ -3,11 +3,11 @@
 eclipse:  # noqa var-naming[no-role-prefix]
   # Ensure the URL does not specify a mirror and that &r=1 is at the end, which
   # directly links to the file and not the web page with a download button
-  url: 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/2023-06/R/eclipse-java-2023-06-R-linux-gtk-{{ ansible_architecture }}.tar.gz&r=1'
-  url_backup: 'https://download.eclipse.org/technology/epp/downloads/release/2023-06/R/eclipse-java-2023-06-R-linux-gtk-{{ ansible_architecture }}.tar.gz'
+  url: 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/2023-12/R/eclipse-java-2023-12-R-linux-gtk-{{ ansible_architecture }}.tar.gz&r=1'
+  url_backup: 'https://download.eclipse.org/technology/epp/downloads/release/2023-12/R/eclipse-java-2023-12-R-linux-gtk-{{ ansible_architecture }}.tar.gz'
   hash:
-    x86_64: '8a54f3fb7abb3203559b4db403681a815edc406a'
-    aarch64: '958626a64c455c5e1a9e14c44526748ba2ce81d9'
+    x86_64: '04a289df397b52bb08e6eb4bd4d2ff93a8120d61'
+    aarch64: 'ab34d85d657cd7fae55215b61cf4ed4868b53a4e'
   zip: '{{ common_global_base_path }}/eclipse.tar.gz'
   install_path: '{{ common_global_base_path }}/eclipse'
 


### PR DESCRIPTION
Please forgive me for this.... Eclipse 2023-09 introduced a "feature" where the plugin installer runs with byte-level debugging to stdout and generates so much garbage that it crashes Ansible. I never did get to solving that, but this jumps us to 2023-12 and introduces a logging config file and parameter to silence the debugging. Tested locally, and the 159 role now succeeds with this in place.