### PR TITLE
Use Mint 21.3 Edge image

### DIFF
--- a/packer/mint-beta.pkrvars.hcl
+++ b/packer/mint-beta.pkrvars.hcl
@@ -1,6 +1,6 @@
 semester = "Fa23"
 
 mint_version = {
-  version = "21.3"
-  beta    = true
+  version    = "21.3"
+  build_type = "beta"
 }

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -1,11 +1,11 @@
 variable "mint_version" {
   type = object({
-    version = string
-    beta    = bool
+    version    = string
+    build_type = string
   })
   default = {
-    version = "21.3"
-    beta    = false
+    version    = "21.3"
+    build_type = "edge"
   }
 }
 
@@ -78,8 +78,8 @@ locals {
     iso_file   = "ubuntu-${var.ubuntu_version.patched_version}-desktop-amd64.iso"
   }
   mint_info = {
-    mirror_url = "${var.mirror.base}/${var.mirror.mint_path}/${var.mint_version.beta ? "testing" : "stable/${var.mint_version.version}"}"
-    iso_file   = "linuxmint-${var.mint_version.version}-cinnamon-64bit${var.mint_version.beta ? "-beta" : ""}.iso"
+    mirror_url = "${var.mirror.base}/${var.mirror.mint_path}/${var.mint_version.build_type == "beta" ? "testing" : "stable/${var.mint_version.version}"}"
+    iso_file   = "linuxmint-${var.mint_version.version}-cinnamon-64bit${var.mint_version.build_type != null ? "-${var.mint_version.build_type}" : ""}.iso"
   }
   artifact_dir_prefix = "${path.cwd}/artifacts_"
 }


### PR DESCRIPTION
We probably don't need to start out with the 6.5 kernel but why should
that stop us from doing it anyway?

This changes the `beta` variable to a `build_type` variable (which
avoids needing to handle both edge/beta being set).