### PR TITLE
Wilma beta

### DIFF
--- a/packer/mint-beta.pkrvars.hcl
+++ b/packer/mint-beta.pkrvars.hcl
@@ -1,6 +1,6 @@
-semester = "Sp24"
+semester = "Fa24"
 
 mint_version = {
-  version    = "21.3"
+  version    = "22"
   build_type = "beta"
 }

--- a/roles/basic_prog_pkgs/tasks/main.yml
+++ b/roles/basic_prog_pkgs/tasks/main.yml
@@ -4,11 +4,3 @@
   ansible.builtin.apt:
     name: '{{ basic_prog_pkgs_intro_development }}'
     state: latest
-
-- name: Install intro pip packages
-  ansible.builtin.pip:
-    name: '{{ basic_prog_pkgs_pip }}'
-    state: present
-  become: yes
-  become_user: "{{ item.user }}"
-  loop: "{{ real_users }}"

--- a/roles/basic_prog_pkgs/vars/main.yml
+++ b/roles/basic_prog_pkgs/vars/main.yml
@@ -8,7 +8,7 @@ basic_prog_pkgs_intro_development:
  - meld
  - python-is-python3
  - python3-flake8-docstrings
- - sqlite
+ - sqlite3
  - sqlitebrowser
  - thonny
 

--- a/roles/basic_prog_pkgs/vars/main.yml
+++ b/roles/basic_prog_pkgs/vars/main.yml
@@ -11,6 +11,3 @@ basic_prog_pkgs_intro_development:
  - sqlite3
  - sqlitebrowser
  - thonny
-
-basic_prog_pkgs_pip:
- - darglint

--- a/roles/common/templates/mint.j2
+++ b/roles/common/templates/mint.j2
@@ -12,12 +12,7 @@ deb {{ mirror }} {{ ubuntu_release }}-backports main restricted universe multive
 deb {{ mirror }} {{ ubuntu_release }}-security main restricted universe multiverse
 
 {% endfor %}
-
 {% for mirror in common_mint_mirrors %}
 # Mint sources for {{ mirror }}
 deb {{ mirror }} {{ ansible_distribution_release }} main upstream import backport
-
 {% endfor %}
-
-# Parter repository (necessary for optional media codecs) -- not mirrored
-deb http://archive.canonical.com/ubuntu {{ ubuntu_release }} partner

--- a/roles/common/templates/ubuntu.j2
+++ b/roles/common/templates/ubuntu.j2
@@ -9,8 +9,4 @@ deb {{ mirror }} {{ ubuntu_release }} main restricted universe multiverse
 deb {{ mirror }} {{ ubuntu_release }}-updates main restricted universe multiverse
 deb {{ mirror }} {{ ubuntu_release }}-backports main restricted universe multiverse
 deb {{ mirror }} {{ ubuntu_release }}-security main restricted universe multiverse
-
 {% endfor %}
-
-# Parter repository (necessary for optional media codecs) -- not mirrored
-deb http://archive.canonical.com/ubuntu {{ ubuntu_release }} partner

--- a/roles/programming_langs/vars/main.yml
+++ b/roles/programming_langs/vars/main.yml
@@ -4,7 +4,9 @@ programming_langs_ruby_packages:
   - ruby
 
 programming_langs_haskell_packages:
-  - haskell-platform
+  - ghc
+  - ghc-doc
+  - ghc-prof
 
 programming_langs_prolog_packages:
   - swi-prolog


### PR DESCRIPTION
Updated beta vars for Wilma, and Packer runs cleanly. A few Ubuntu 24.04 fixes in our course playbooks though:

- The partner (codec) repo appears to have been deprecated for some time and is now finally dead
- The `sqlite` package for sqlite2 has been dropped in favor of `sqlite3`
- Ansible/python no longer allows system-wide pip installs, which is what we used for darglint. In Ansible 2.17 you can force install, but we're stuck with 2.16. Also, darglint has been abandoned. There is a darglint2 spiritual successor, but even that maintainer suggests finding something else. I just dropped all of it for now.
- `haskell-platform` has been dropped, so I reverted to installing ghc directly