### PR TITLE
Fix pylint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   Ansible:
     name: Run Ansible lint tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.x
@@ -30,7 +30,7 @@ jobs:
           yamllint .github/workflows/*yml
   Packer:
     name: Run Packer lint tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -76,7 +76,7 @@ jobs:
           pylint roles/*/*/*.py scripts/*.py
   Shell:
     name: Run Shell linting
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@master
@@ -91,7 +91,7 @@ jobs:
           shellcheck --shell=bash scripts/oem-build roles/user/files/csvmprofile
   Hashes:
     name: Validate file hashes
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Cleaning up to resolve test failures from #554. Looks like we can use pure apt packages for dependencies, which is a bit heavier, but keeps us in sync with the VM. Also, updated all jobs to 24.04 while I was in there.