### PR TITLE
Update beta to 22.2 Zara

### DIFF
--- a/packer/main.pkr.hcl
+++ b/packer/main.pkr.hcl
@@ -13,7 +13,7 @@ source "virtualbox-iso" "base-build" {
   memory        = 4096
   disk_size     = 20480
   guest_os_type = "Ubuntu_64"
-  gfx_vram_size = 64
+  gfx_vram_size = 128
 
   format                   = "ova"
   firmware                 = "efi"

--- a/packer/mint-beta.pkrvars.hcl
+++ b/packer/mint-beta.pkrvars.hcl
@@ -1,6 +1,6 @@
-semester = "Sp25"
+semester = "Fa25"
 
 mint_version = {
-  version    = "22.1"
+  version    = "22.2"
   build_type = "beta"
 }


### PR DESCRIPTION
Kernel panic on first boot after OEM, but other than that the basics seem to check out.