### PR TITLE
Zara release

### DIFF
--- a/packer/http/oem-preseed.cfg
+++ b/packer/http/oem-preseed.cfg
@@ -62,6 +62,7 @@ ubiquity ubiquity/success_command string svcfile="/target/etc/systemd/system/ssh
     echo "After=network-online.target"                                   >> "$svcfile"; \
     echo "Requires=network-online.target"                                >> "$svcfile"; \
     echo "[Service]"                                                     >> "$svcfile"; \
+    echo "ExecStartPre=/bin/bash -c 'echo nameserver 8.8.8.8 > /etc/resolv.conf'" >> "$svcfile"; \
     echo "ExecStartPre=/usr/bin/apt-get update"                          >> "$svcfile"; \
     echo "ExecStart=/usr/bin/apt-get -y install openssh-server"          >> "$svcfile"; \
     echo "ExecStartPost=/bin/systemctl disable ssh-install.service"      >> "$svcfile"; \

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -4,7 +4,7 @@ variable "mint_version" {
     build_type = string
   })
   default = {
-    version    = "22.1"
+    version    = "22.2"
     build_type = null
   }
 }
@@ -53,7 +53,7 @@ variable "headless" {
 
 variable "semester" {
   type    = string
-  default = "Sp25"
+  default = "Fa25"
 }
 
 variable "ssh_pass" {


### PR DESCRIPTION
Putting this out for early consideration, but I wouldn't merge it yet. VBox 7.2 seems to have a DNS resolution bug (https://github.com/VirtualBox/virtualbox/issues/136) on Linux hosts. Neither `--natdnsproxy1 on` or `--natdnshostresolver1 on` from https://www.virtualbox.org/manual/topics/networkingdetails.html#nat_host_resolver_proxy seemed to help.

7e8f918bd07dc520a86d1c0df8b1bbbc5bfd8820 allows the image build to complete, but I would not recommend we consider this long-term.