### PR TITLE
Zena update

### DIFF
--- a/packer/main.pkr.hcl
+++ b/packer/main.pkr.hcl
@@ -11,7 +11,7 @@ packer {
 source "virtualbox-iso" "base-build" {
   cpus          = 2
   memory        = 4096
-  disk_size     = 20480
+  disk_size     = 25600
   guest_os_type = "Ubuntu_64"
   gfx_vram_size = 128
 

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -4,7 +4,7 @@ variable "mint_version" {
     build_type = string
   })
   default = {
-    version    = "22.2"
+    version    = "22.3"
     build_type = null
   }
 }
@@ -53,7 +53,7 @@ variable "headless" {
 
 variable "semester" {
   type    = string
-  default = "Fa25"
+  default = "Sp26"
 }
 
 variable "ssh_pass" {

--- a/roles/eclipse/vars/main.yml
+++ b/roles/eclipse/vars/main.yml
@@ -3,11 +3,11 @@
 eclipse:  # noqa var-naming[no-role-prefix]
   # Ensure the URL does not specify a mirror and that &r=1 is at the end, which
   # directly links to the file and not the web page with a download button
-  url: 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/2025-06/R/eclipse-java-2025-06-R-linux-gtk-{{ ansible_architecture }}.tar.gz&r=1'
-  url_backup: 'https://download.eclipse.org/technology/epp/downloads/release/2025-06/R/eclipse-java-2025-06-R-linux-gtk-{{ ansible_architecture }}.tar.gz'
+  url: 'https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/2026-03/R/eclipse-java-2026-03-R-linux-gtk-{{ ansible_architecture }}.tar.gz&r=1'
+  url_backup: 'https://download.eclipse.org/technology/epp/downloads/release/2026-03/R/eclipse-java-2026-03-R-linux-gtk-{{ ansible_architecture }}.tar.gz'
   hash:
-    x86_64: 'd8871b00a7ac8b18cf8eab55fd6ae1cd73e8ef02'
-    aarch64: 'e7b6fd835880f7297fa27d1fe64a72f959b58f5c'
+    x86_64: '2f25adf74cac86a64cc24c454a039a3b02b93c5a'
+    aarch64: 'a65e3aac7efb11c3597082ffb72881470f0cf77c'
   zip: '{{ common_global_base_path }}/eclipse.tar.gz'
   install_path: '{{ common_global_base_path }}/eclipse'
 

--- a/roles/vscode/tasks/main.yml
+++ b/roles/vscode/tasks/main.yml
@@ -4,17 +4,22 @@
   ansible.builtin.apt_key:
     id: BC528686B50D79E339D3721CEB3E94ADBE1229CF
     url: https://packages.microsoft.com/keys/microsoft.asc
-    keyring: /etc/apt/trusted.gpg.d/packages.microsoft.gpg
+    keyring: /usr/share/keyrings/microsoft.gpg
     state: present
 - name: Install VSCode Repository file
-  ansible.builtin.apt_repository:
-    repo: deb [arch=amd64,arm64,armhf signed-by=/etc/apt/trusted.gpg.d/packages.microsoft.gpg] https://packages.microsoft.com/repos/code stable main
-    state: present
-    filename: vscode
+  ansible.builtin.deb822_repository:
+    name: vscode
+    types: deb
+    uris: https://packages.microsoft.com/repos/code
+    suites: stable
+    components:
+      - main
+    signed_by: /usr/share/keyrings/microsoft.gpg
 - name: Install VSCode
   ansible.builtin.apt:
     name: 'code'
     state: latest
+    update_cache: yes
 - name: Install Java pack plugin
   ansible.builtin.command:
     cmd: /usr/bin/code --install-extension vscjava.vscode-java-pack


### PR DESCRIPTION
Went in to bump the Mint version. Decided to bump Eclipse while I was there. Realized that with all roles installed, we only have 1.8GB left free, so bumped the disk size to 25GB. Re-ran the playbook and it died on VS Code because they install a conflicting modernized apt source file.

Anyways, things working as they used to and the world can go on ignoring this.